### PR TITLE
feat: Simplify Mover interface

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - dupl
     - gofmt
     - goimports
+    # golint replacement
     - revive
     - gosimple
     - govet

--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -8,15 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/pkg/mover"
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
 const (
@@ -79,69 +76,30 @@ func newChartMoveCmd() *cobra.Command {
 	return cmd
 }
 
-func loadChartFromArgs(args []string) (*chart.Chart, error) {
-	sourceChart, err := loader.Load(args[0])
-	if err != nil {
-		return nil, fmt.Errorf("failed to load Helm Chart at \"%s\": %w", args[0], err)
-	}
-
-	return sourceChart, nil
-}
-
-func loadImagePatterns(chart *chart.Chart) (string, error) {
-	patterns, err := mover.LoadImagePatterns(imagePatternsFile, chart)
-	if err != nil {
-		return "", fmt.Errorf("failed to read image pattern file: %w", err)
-	}
-	if patterns == "" {
-		return patterns, errors.New("image patterns file is required. Please try again with '--image-patterns <image patterns file>'")
-	}
-	if imagePatternsFile == "" {
-		log.Println("Using embedded image patterns file.")
-	}
-	return patterns, nil
-}
-
 func moveChart(cmd *cobra.Command, args []string) error {
-	sourceChart, err := loadChartFromArgs(args)
-	if err != nil {
-		return err
-	}
-
-	imagePatterns, err := loadImagePatterns(sourceChart)
-	if err != nil {
-		return err
-	}
-
-	if registryRule == "" && repositoryPrefixRule == "" {
-		return errors.New("at least one rewrite rule must be given. Please try again with --registry and/or --repo-prefix")
-	}
-
 	targetRewriteRules := &mover.RewriteRules{
 		Registry:         registryRule,
 		RepositoryPrefix: repositoryPrefixRule,
 	}
 
-	outputFmt, err := parseOutputFlag(output)
-	if err != nil {
-		return fmt.Errorf("failed to move chart: %w", err)
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get current working dir: %w", err)
-	}
-	destinationFile := targetOutput(cwd, outputFmt, sourceChart.Name(), sourceChart.Metadata.Version)
-
 	cmd.Println("Computing relocation...")
+
 	chartMover, err := mover.NewChartMover(
-		sourceChart,
-		imagePatterns,
+		args[0],
+		imagePatternsFile,
 		targetRewriteRules,
 		mover.WithRetries(retries), mover.WithLogger(cmd),
 	)
 	if err != nil {
+		if err == mover.ErrImageHintsMissing {
+			return fmt.Errorf("image patterns file is required. Please try again with '--image-patterns <image patterns file>' or as part of the Helm chart at [chart]/%s file", mover.EmbeddedHintsFilename)
+		} else if err == mover.ErrOCIRewritesMissing {
+			return fmt.Errorf("at least one rewrite rule must be given. Please try again with --registry and/or --repo-prefix")
+		}
+
 		return err
 	}
+
 	chartMover.Print()
 
 	if !skipConfirmation {
@@ -156,6 +114,18 @@ func moveChart(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 	}
+
+	outputFmt, err := parseOutputFlag(output)
+	if err != nil {
+		return fmt.Errorf("failed to move chart: %w", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working dir: %w", err)
+	}
+
+	destinationFile := targetOutput(cwd, outputFmt, chartMover.ChartName, chartMover.ChartVersion)
 
 	return chartMover.Move(destinationFile)
 }

--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -125,7 +125,12 @@ func moveChart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get current working dir: %w", err)
 	}
 
-	destinationFile := targetOutput(cwd, outputFmt, chartMover.ChartName, chartMover.ChartVersion)
+	chartMetadata, err := chartMover.ChartMetadata()
+	if err != nil {
+		return err
+	}
+
+	destinationFile := targetOutput(cwd, outputFmt, chartMetadata.Name, chartMetadata.Version)
 
 	return chartMover.Move(destinationFile)
 }

--- a/internal/image_template.go
+++ b/internal/image_template.go
@@ -76,9 +76,9 @@ func NewFromString(input string) (*ImageTemplate, error) {
 	return imageTemplate, nil
 }
 
-func ParseImagePatterns(patterns string) ([]*ImageTemplate, error) {
+func ParseImagePatterns(patterns []byte) ([]*ImageTemplate, error) {
 	var templateStrings []string
-	err := yaml.Unmarshal(([]byte)(patterns), &templateStrings)
+	err := yaml.Unmarshal(patterns, &templateStrings)
 	if err != nil {
 		return nil, fmt.Errorf("image pattern file is not in the correct format: %w", err)
 	}

--- a/pkg/mover/chart.go
+++ b/pkg/mover/chart.go
@@ -16,22 +16,29 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 )
 
-// Number of retries for pull/push operations
 const (
-	DefaultRetries        = 3
+	// EmbeddedHintsFilename to be present in the Helm Chart rootpath
 	EmbeddedHintsFilename = ".relok8s-images.yaml"
+	// DefaultRetries indicates the default number of retries for pull/push operations
+	DefaultRetries = 3
 )
 
 var (
-	ErrImageHintsMissing  = errors.New("no image hints provided")
+	// ErrImageHintsMissing indicates that neither the hints file was provided nor found in the Helm chart
+	ErrImageHintsMissing = errors.New("no image hints provided")
+	// ErrOCIRewritesMissing indicates that no rewrite rules have been provided
 	ErrOCIRewritesMissing = errors.New("at least one rewrite rule is required")
 )
 
+// RewriteRules indicate What kind of target registry overrides we want to apply to the found images
 type RewriteRules struct {
-	Registry         string
+	// Registry overrides the registry part of the image FQDN, i.e myregistry.io
+	Registry string
+	// RepositoryPrefix will override the image path by being prepended before the image name
 	RepositoryPrefix string
 }
 
+// Logger represents an interface used to output moving information
 type Logger interface {
 	Printf(format string, i ...interface{})
 	Println(i ...interface{})
@@ -47,16 +54,19 @@ func (l *defaultLogger) Println(i ...interface{}) {
 	fmt.Println(i...)
 }
 
+// ChartMover represents a Helm Chart moving relocation. It's initialization must be done view NewChartMover
 type ChartMover struct {
-	chart *chart.Chart
-	// Extracted metadata from the provided Helm Chart
-	ChartName    string
-	ChartVersion string
-
+	chart        *chart.Chart
 	imageChanges []*internal.ImageChange
 	chartChanges []*internal.RewriteAction
 	logger       Logger
 	retries      uint
+}
+
+// ChartMetadata exposes metadata about the Helm Chart to be relocated
+type ChartMetadata struct {
+	Name    string
+	Version string
 }
 
 // NewChartMover creates a ChartMover to relocate a chart following the given
@@ -72,11 +82,9 @@ func NewChartMover(chartPath string, imageHintsFile string, rules *RewriteRules,
 	}
 
 	c := &ChartMover{
-		chart:        chart,
-		ChartName:    chart.Name(),
-		ChartVersion: chart.Metadata.Version,
-		logger:       &defaultLogger{},
-		retries:      DefaultRetries,
+		chart:   chart,
+		logger:  &defaultLogger{},
+		retries: DefaultRetries,
 	}
 
 	// Option overrides
@@ -116,13 +124,15 @@ func NewChartMover(chartPath string, imageHintsFile string, rules *RewriteRules,
 	return c, nil
 }
 
-// WithRetries customizes the mover push retries
+// WithRetries sets how many times to retry push operations
 func (cm *ChartMover) WithRetries(retries uint) *ChartMover {
 	cm.retries = retries
 	return cm
 }
 
-// Print dumps the chart mover changes to the mover logger
+// Print shows the changes expected to be performed during relocation,
+// including the new location of the Helm Chart Images as well as
+// the expected rewrites in the Helm Chart.
 func (cm *ChartMover) Print() {
 	log := cm.logger
 	log.Println("Image moves:")
@@ -146,8 +156,15 @@ func (cm *ChartMover) Print() {
 	}
 }
 
-// Move executes the chart move image and chart changes.
-// The result chart is saved as toChartFilename.
+/*
+Move executes the Chart relocation which includes
+
+1 - Push all the images to their new locations
+
+2 - Rewrite the Helm Chart and its subcharts
+
+3 - Repackage the Helm chart as toChartFilename
+*/
 func (cm *ChartMover) Move(toChartFilename string) error {
 	log := cm.logger
 	err := pushRewrittenImages(cm.imageChanges, cm.retries, log)
@@ -161,6 +178,18 @@ func (cm *ChartMover) Move(toChartFilename string) error {
 	}
 	log.Println("Done")
 	return nil
+}
+
+// ChartMetadata returns information from the Helm Chart ready to be relocated
+func (cm *ChartMover) ChartMetadata() (*ChartMetadata, error) {
+	if cm.chart == nil {
+		return nil, errors.New("Helm Chart not loaded")
+	}
+
+	return &ChartMetadata{
+		Name:    cm.chart.Name(),
+		Version: cm.chart.Metadata.Version,
+	}, nil
 }
 
 func pullOriginalImages(chart *chart.Chart, pattens []*internal.ImageTemplate) ([]*internal.ImageChange, error) {
@@ -338,6 +367,7 @@ func loadPatternsFromFile(patternsFile string, log Logger) ([]byte, error) {
 	return contents, nil
 }
 
+// Option adds optional functionality to NewChartMover constructor
 type Option func(*ChartMover)
 
 // WithRetries defines how many times to retry the push operation

--- a/pkg/mover/chart_test.go
+++ b/pkg/mover/chart_test.go
@@ -439,32 +439,34 @@ const (
 )
 
 var _ = Describe("LoadImagePatterns", func() {
+	logger := &defaultLogger{}
+
 	It("reads from given file first if present", func() {
 		imagefile := filepath.Join(fixturesRoot, "testchart.images.yaml")
-		contents, err := LoadImagePatterns(imagefile, nil)
+		contents, err := loadPatterns(imagefile, nil, logger)
 		Expect(err).ToNot(HaveOccurred())
 
 		expected, err := os.ReadFile(imagefile)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(contents).To(Equal(string(expected)))
+		Expect(contents).To(Equal(expected))
 	})
 	It("reads from chart if file missing", func() {
 		chart, err := loader.Load(filepath.Join(fixturesRoot, "self-relok8ing-chart"))
 		Expect(err).ToNot(HaveOccurred())
 
-		contents, err := LoadImagePatterns("", chart)
+		contents, err := loadPatterns("", chart, logger)
 		Expect(err).ToNot(HaveOccurred())
 
 		embeddedPatterns := filepath.Join(fixturesRoot, "self-relok8ing-chart/.relok8s-images.yaml")
 		expected, err := os.ReadFile(embeddedPatterns)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(contents).To(Equal(string(expected)))
+		Expect(contents).To(Equal(expected))
 	})
 	It("reads nothing when no file and the chart is not self relok8able", func() {
 		chart, err := loader.Load(filepath.Join(fixturesRoot, "testchart"))
 		Expect(err).ToNot(HaveOccurred())
 
-		contents, err := LoadImagePatterns("", chart)
+		contents, err := loadPatterns("", chart, logger)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(contents).To(BeEmpty())
 	})

--- a/pkg/mover/doc_test.go
+++ b/pkg/mover/doc_test.go
@@ -1,9 +1,14 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 package mover
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Package level documentation
-func Example() error {
+func Example() {
 	// Initialize the Mover action
 	chartMover, err := NewChartMover(
 		// The Helm Chart can be provided in either tarball or directory form
@@ -18,28 +23,22 @@ func Example() error {
 		},
 	)
 	if err != nil {
-		if err == ErrImageHintsMissing {
-			return fmt.Errorf("image patterns file is required", EmbeddedHintsFilename)
-		} else if err == ErrOCIRewritesMissing {
-			return fmt.Errorf("at least one rewrite rule must be given")
-		}
-
-		return err
+		fmt.Println(err)
+		return
 	}
 
-	// Next we just need to call Move providing the destinatin path of the rewritten Helm Chart
+	// Next we just need to call Move providing the destination path of the rewritten Helm Chart
 	// i.e chartMover.Move("./helm-chart-relocated.tgz")
 	// Additionally, some extra metadata about the provided Helm Chart can be retrieved.
 	// Useful to generate custom destination filepaths
 	chartMetadata, err := chartMover.ChartMetadata()
 	if err != nil {
-		return err
+		fmt.Println(err)
+		return
 	}
 
 	// i.e ./mariadb-7.5.relocated.tgz
 	destinationPath := fmt.Sprintf("./%s-%s.relocated.tgz", chartMetadata.Name, chartMetadata.Version)
 	// Perform the push, rewrite and repackage of the Helm Chart
 	chartMover.Move(destinationPath)
-
-	return nil
 }

--- a/pkg/mover/doc_test.go
+++ b/pkg/mover/doc_test.go
@@ -1,0 +1,45 @@
+package mover
+
+import "fmt"
+
+// Package level documentation
+func Example() error {
+	// Initialize the Mover action
+	chartMover, err := NewChartMover(
+		// The Helm Chart can be provided in either tarball or directory form
+		"./helm_chart.tgz",
+		// path to file containing rules such as // {{.image.registry}}:{{.image.tag}}
+		"./image-hints.yaml",
+		// Where to push and how to rewrite the found images
+		// i.e docker.io/bitnami/mariadb => myregistry.com/myteam/mariadb
+		&RewriteRules{
+			Registry:         "myregistry.com",
+			RepositoryPrefix: "/myteam",
+		},
+	)
+	if err != nil {
+		if err == ErrImageHintsMissing {
+			return fmt.Errorf("image patterns file is required", EmbeddedHintsFilename)
+		} else if err == ErrOCIRewritesMissing {
+			return fmt.Errorf("at least one rewrite rule must be given")
+		}
+
+		return err
+	}
+
+	// Next we just need to call Move providing the destinatin path of the rewritten Helm Chart
+	// i.e chartMover.Move("./helm-chart-relocated.tgz")
+	// Additionally, some extra metadata about the provided Helm Chart can be retrieved.
+	// Useful to generate custom destination filepaths
+	chartMetadata, err := chartMover.ChartMetadata()
+	if err != nil {
+		return err
+	}
+
+	// i.e ./mariadb-7.5.relocated.tgz
+	destinationPath := fmt.Sprintf("./%s-%s.relocated.tgz", chartMetadata.Name, chartMetadata.Version)
+	// Perform the push, rewrite and repackage of the Helm Chart
+	chartMover.Move(destinationPath)
+
+	return nil
+}

--- a/test/chart_move_feature_test.go
+++ b/test/chart_move_feature_test.go
@@ -71,7 +71,7 @@ var _ = Describe("relok8s chart move command", func() {
 	})
 
 	Scenario("missing image patterns file", func() {
-		steps.When("running relok8s chart move fixtures/wordpress-11.0.4.tgz")
+		steps.When("running relok8s chart move fixtures/wordpress-11.0.4.tgz --repo-prefix cyberdyne-corp")
 		steps.Then("the command exits with an error")
 		steps.And("it says the image patterns file is missing")
 		steps.And("it prints the usage")


### PR DESCRIPTION
Split from https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/37

Changes the mover constructor signature to not to require the caller to import and load neither the Helm Chart nor the imagehints file. A path to those will suffice now. 

Signed-off-by: Miguel Martinez Trivino <mtrivino@vmware.com>