### PR TITLE
feat(ci): Add golang-ci configuration and CI action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,22 +5,14 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v1
-        with:
-          go-version: "1.16"
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.41.1
-          args: -v
+          version: v1.42

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.16"
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.41.1
+          args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,34 @@
+run:
+  timeout: 10m
+  skip-dirs:
+    - vendor
+
+linters:
+  disable-all: true
+  enable:
+    - goheader
+    - deadcode
+    - dupl
+    - gofmt
+    - goimports
+    - revive
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - structcheck
+    - unused
+    - varcheck
+    - staticcheck
+
+linters-settings:
+  gofmt:
+    simplify: true
+  dupl:
+    threshold: 400
+  goheader:
+    values:
+      regexp:
+        copyright-year: 2021
+    template-path: code-header-template.txt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,8 @@
 run:
   timeout: 10m
-  skip-dirs:
-    - vendor
+  build-tags:
+    - feature
+    - external
 
 linters:
   disable-all: true
@@ -21,7 +22,7 @@ linters:
     - unused
     - varcheck
     - staticcheck
-
+    
 linters-settings:
   gofmt:
     simplify: true

--- a/Makefile
+++ b/Makefile
@@ -106,11 +106,7 @@ test-all: test test-external
 
 # https://golangci-lint.run/usage/install/#local-installation
 lint: deps-golangci-lint
-	golangci-lint run --new-from-rev=origin/main
-
-lint-all: deps-golangci-lint
 	golangci-lint run
-
 
 # #### DEVOPS ####
 .PHONY: set-pipeline set-example-pipeline

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ test-all: test test-external
 
 # https://golangci-lint.run/usage/install/#local-installation
 lint: deps-golangci-lint
+	golangci-lint run --new-from-rev=origin/main
+
+lint-all: deps-golangci-lint
 	golangci-lint run
 
 

--- a/Makefile
+++ b/Makefile
@@ -25,20 +25,28 @@ endif
 HAS_COUNTERFEITER := $(shell command -v counterfeiter;)
 HAS_GINKGO := $(shell command -v ginkgo;)
 HAS_GO_IMPORTS := $(shell command -v goimports;)
+HAS_GOLANGCI_LINT := $(shell command -v golangci-lint;)
 
+# If go get is run from inside the project directory it will add the dependencies
+# to the go.mod file. To avoid that we import from another directory
 deps-goimports: deps-go-binary
 ifndef HAS_GO_IMPORTS
-	go get -u golang.org/x/tools/cmd/goimports
+	cd /; go get -u golang.org/x/tools/cmd/goimports
 endif
 
 deps-counterfeiter: deps-go-binary
 ifndef HAS_COUNTERFEITER
-	go get -u github.com/maxbrunsfeld/counterfeiter/v6
+	cd /; go get -u github.com/maxbrunsfeld/counterfeiter/v6
 endif
 
 deps-ginkgo: deps-go-binary
 ifndef HAS_GINKGO
-	go get -u github.com/onsi/ginkgo/ginkgo github.com/onsi/gomega
+	cd /; go get github.com/onsi/ginkgo/ginkgo github.com/onsi/gomega
+endif
+
+deps-golangci-lint: deps-go-binary deps-goimports
+ifndef HAS_GOLANGCI_LINT
+	cd /; go get github.com/golangci/golangci-lint/cmd/golangci-lint
 endif
 
 # #### CLEAN ####
@@ -96,8 +104,9 @@ test: deps lint test-units test-features
 
 test-all: test test-external
 
-lint: deps-goimports
-	git ls-files | grep -v '^vendor/' | grep '.go$$' | xargs goimports -l -w
+# https://golangci-lint.run/usage/install/#local-installation
+lint: deps-golangci-lint
+	golangci-lint run
 
 
 # #### DEVOPS ####

--- a/code-header-template.txt
+++ b/code-header-template.txt
@@ -1,0 +1,2 @@
+Copyright {{copyright-year}} VMware, Inc.
+SPDX-License-Identifier: BSD-2-Clause

--- a/internal/image.go
+++ b/internal/image.go
@@ -1,7 +1,7 @@
-package internal
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package internal
 
 import (
 	"fmt"
@@ -49,9 +49,9 @@ func (i *ImageImpl) Check(digest string, imageReference name.Reference) (bool, e
 
 	if remoteDigest != digest {
 		return false, fmt.Errorf("remote image \"%s\" already exists with a different digest: %s. Will not overwrite", imageReference.Name(), remoteDigest)
-	} else {
-		return false, nil
 	}
+
+	return false, nil
 }
 
 func (i *ImageImpl) Push(image v1.Image, dest name.Reference) error {

--- a/internal/image_change.go
+++ b/internal/image_change.go
@@ -1,7 +1,7 @@
-package internal
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package internal
 
 import (
 	"github.com/google/go-containerregistry/pkg/name"

--- a/internal/image_template.go
+++ b/internal/image_template.go
@@ -1,7 +1,7 @@
-package internal
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package internal
 
 import (
 	"fmt"

--- a/internal/image_template_test.go
+++ b/internal/image_template_test.go
@@ -1,7 +1,7 @@
-package internal_test
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package internal_test
 
 import (
 	"github.com/google/go-containerregistry/pkg/name"

--- a/internal/rewrite_action.go
+++ b/internal/rewrite_action.go
@@ -1,7 +1,7 @@
-package internal
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package internal
 
 import (
 	"bytes"
@@ -49,7 +49,7 @@ func (a *RewriteAction) ToMap() map[string]interface{} {
 	var node ValuesMap
 	var value interface{} = a.Value
 
-	for i := len(keys) - 1; i >= 0; i -= 1 {
+	for i := len(keys) - 1; i >= 0; i-- {
 		key := keys[i]
 		node = make(ValuesMap)
 		node[key] = value
@@ -171,7 +171,7 @@ func (t *ImageTemplate) Apply(originalImage name.Reference, rules *OCIImageLocat
 		newRepository = fmt.Sprintf("%s/%s", rules.RepositoryPrefix, imageName)
 	}
 
-	// Append the image digest unless the tag or digest are explicitely encoded in the template
+	// Append the image digest unless the tag or digest are explicitly encoded in the template
 	if t.TagTemplate == "" && t.DigestTemplate == "" && rules.Digest != "" {
 		newRepository = fmt.Sprintf("%s@%s", newRepository, rules.Digest)
 	}
@@ -196,7 +196,7 @@ func (t *ImageTemplate) Apply(originalImage name.Reference, rules *OCIImageLocat
 	if t.RepositoryTemplate != "" && newRepository != "" {
 		rewrites = append(rewrites, &RewriteAction{
 			Path:  t.RepositoryTemplate,
-			Value: fmt.Sprintf("%s", newRepository),
+			Value: newRepository,
 		})
 	}
 

--- a/internal/rewrite_action_test.go
+++ b/internal/rewrite_action_test.go
@@ -1,7 +1,7 @@
-package internal_test
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package internal_test
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/internal/yamlops/helpers_test.go
+++ b/internal/yamlops/helpers_test.go
@@ -1,7 +1,7 @@
-package yamlops_test
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package yamlops_test
 
 import (
 	"testing"

--- a/internal/yamlops/nodesearch.go
+++ b/internal/yamlops/nodesearch.go
@@ -1,7 +1,7 @@
-package yamlops
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package yamlops
 
 import (
 	"strings"

--- a/internal/yamlops/nodesearch_test.go
+++ b/internal/yamlops/nodesearch_test.go
@@ -1,7 +1,7 @@
-package yamlops_test
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package yamlops_test
 
 import (
 	"reflect"

--- a/internal/yamlops/scanner.go
+++ b/internal/yamlops/scanner.go
@@ -1,7 +1,7 @@
-package yamlops
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package yamlops
 
 import (
 	"fmt"

--- a/internal/yamlops/scanner_test.go
+++ b/internal/yamlops/scanner_test.go
@@ -1,7 +1,7 @@
-package yamlops_test
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package yamlops_test
 
 import (
 	"reflect"

--- a/internal/yamlops/yamlops.go
+++ b/internal/yamlops/yamlops.go
@@ -1,7 +1,7 @@
-package yamlops
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package yamlops
 
 import (
 	"bufio"

--- a/internal/yamlops/yamlops_test.go
+++ b/internal/yamlops/yamlops_test.go
@@ -1,7 +1,7 @@
-package yamlops_test
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package yamlops_test
 
 import (
 	"strings"
@@ -84,7 +84,7 @@ func TestUpdateMap(t *testing.T) {
 			"a:\n  foo: new\nb:\n  foo: old",
 		},
 		{
-			"doesn't update map with non-existant path",
+			"doesn't update map with non-existent path",
 			"a:\n  foo: a foo",
 			".b",
 			nil,

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
-package main
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package main
 
 import (
 	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/cmd"

--- a/pkg/mover/chart.go
+++ b/pkg/mover/chart.go
@@ -31,12 +31,10 @@ type defaultLogger struct{}
 
 func (l *defaultLogger) Printf(format string, i ...interface{}) {
 	fmt.Printf(format, i...)
-	return
 }
 
 func (l *defaultLogger) Println(i ...interface{}) {
 	fmt.Println(i...)
-	return
 }
 
 type ChartMover struct {

--- a/test/chart_move_feature_test.go
+++ b/test/chart_move_feature_test.go
@@ -1,9 +1,9 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 // +build feature
 
 package test_test
-
-// Copyright 2021 VMware, Inc.
-// SPDX-License-Identifier: BSD-2-Clause
 
 import (
 	"time"

--- a/test/common_steps.go
+++ b/test/common_steps.go
@@ -1,9 +1,9 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 // +build feature external
 
 package test
-
-// Copyright 2021 VMware, Inc.
-// SPDX-License-Identifier: BSD-2-Clause
 
 import (
 	"os/exec"
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/bunniesandbeatings/goerkin"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gbytes"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 )
 
@@ -22,17 +22,17 @@ var (
 	CommandSession       *gexec.Session
 )
 
-var _ = BeforeSuite(func() {
+var _ = ginkgo.BeforeSuite(func() {
 	var err error
 	ChartMoverBinaryPath, err = gexec.Build(
 		"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2",
 		"-ldflags",
 		"-X github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/cmd.Version=1.2.3",
 	)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
-var _ = AfterSuite(func() {
+var _ = ginkgo.AfterSuite(func() {
 	gexec.CleanupBuildArtifacts()
 })
 
@@ -41,20 +41,20 @@ func DefineCommonSteps(define goerkin.Definitions) {
 		args := strings.Split(argString, " ")
 		command := exec.Command(ChartMoverBinaryPath, args...)
 		var err error
-		CommandSession, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).NotTo(HaveOccurred())
+		CommandSession, err = gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
 	define.Then(`^the command exits without error$`, func() {
-		Eventually(CommandSession, time.Minute).Should(gexec.Exit(0))
+		gomega.Eventually(CommandSession, time.Minute).Should(gexec.Exit(0))
 	})
 
 	define.Then(`^the command exits with an error$`, func() {
-		Eventually(CommandSession, time.Minute).Should(gexec.Exit(1))
+		gomega.Eventually(CommandSession, time.Minute).Should(gexec.Exit(1))
 	})
 
 	define.Then(`^it prints the usage$`, func() {
-		Expect(CommandSession.Err).To(Say("Usage:"))
-		Expect(CommandSession.Err).To(Say("relok8s chart move <chart> \\[flags\\]"))
+		gomega.Expect(CommandSession.Err).To(gbytes.Say("Usage:"))
+		gomega.Expect(CommandSession.Err).To(gbytes.Say("relok8s chart move <chart> \\[flags\\]"))
 	})
 }

--- a/test/features_suite_test.go
+++ b/test/features_suite_test.go
@@ -1,7 +1,7 @@
-package test
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package test
 
 import (
 	"testing"

--- a/test/test_helpers.go
+++ b/test/test_helpers.go
@@ -1,7 +1,7 @@
-package test
-
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
+package test
 
 import (
 	"helm.sh/helm/v3/pkg/chart"

--- a/test/version_test.go
+++ b/test/version_test.go
@@ -1,9 +1,9 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 // +build feature
 
 package test
-
-// Copyright 2021 VMware, Inc.
-// SPDX-License-Identifier: BSD-2-Clause
 
 import (
 	. "github.com/bunniesandbeatings/goerkin"


### PR DESCRIPTION
Closes https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/issues/45

* Adds golangcli-lint configuration. The configuration is based in the one in a couple of projects, Helm, carvels/kapp-controller 
* Updates the `lint` makefile target
* Updates code to meet the linter standards, i.e updates the headers
* Adds a golang-ci Github action that runs on PR and merges in `main`. Enabled in this PR already (see checks)

Linters enabled with that configuration

```bash
$ golangci-lint linters                                           
Enabled by your configuration linters:                                         
deadcode: Finds unused code [fast: false, auto-fix: false]
dupl: Tool for code clone detection [fast: true, auto-fix: false]
gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
goheader: Checks is file header matches to pattern [fast: true, auto-fix: false]
goimports: In addition to fixing imports, goimports also formats your code in the same style as gofmt. [fast: true, auto-fix: true]
gosimple (megacheck): Linter for Go source code that specializes in simplifying a code [fast: false, auto-fix: false]
govet (vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format strin
g [fast: false, auto-fix: false]
ineffassign: Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
misspell: Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
nakedret: Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
revive: Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
staticcheck (megacheck): Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false, auto-fix: false]
structcheck: Finds unused struct fields [fast: false, auto-fix: false]
unused (megacheck): Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
varcheck: Finds unused global variables and constants [fast: false, auto-fix: false]

```

Signed-off-by: Miguel Martinez Trivino <mtrivino@vmware.com>