### PR TITLE
fix(ux): Tweak relocation output

### DIFF
--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -82,8 +82,6 @@ func moveChart(cmd *cobra.Command, args []string) error {
 		RepositoryPrefix: repositoryPrefixRule,
 	}
 
-	cmd.Println("Computing relocation...")
-
 	chartMover, err := mover.NewChartMover(
 		args[0],
 		imagePatternsFile,

--- a/pkg/mover/chart_test.go
+++ b/pkg/mover/chart_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -471,3 +472,23 @@ var _ = Describe("LoadImagePatterns", func() {
 		Expect(contents).To(BeEmpty())
 	})
 })
+
+func TestNamespacedPath(t *testing.T) {
+	tests := []struct {
+		inputPath  string
+		chartName  string
+		outputPath string
+	}{
+		{".image.registry", "app1", ".image.registry"},
+		{".app1.image.registry", "app1", ".image.registry"},
+		{".fooapp1.image.registry", "app1", ".fooapp1.image.registry"},
+		{".image.app1.registry", "app1", ".image.app1.registry"},
+		{".app2.image.registry", "app1", ".app2.image.registry"},
+	}
+
+	for _, tc := range tests {
+		if got, want := namespacedPath(tc.inputPath, tc.chartName), tc.outputPath; got != want {
+			t.Errorf("got=%s; want=%s", got, want)
+		}
+	}
+}

--- a/test/external_test.go
+++ b/test/external_test.go
@@ -37,10 +37,12 @@ var _ = Describe("External tests", func() {
 		steps.When(fmt.Sprintf("running relok8s chart move -y fixtures/testchart --image-patterns fixtures/testchart.images.yaml --repo-prefix %s", customRepoPrefix))
 		steps.And("the move is computed")
 		steps.Then("the command says that the rewritten image will be pushed")
-		steps.And("the command says that the rewritten images will be written to the chart")
+		steps.And("the command says that the rewritten images will be written to the chart and subchart")
 		steps.And("the command exits without error")
+		steps.And("the chart name and version is shown before relocation")
 		steps.And("the rewritten image is pushed")
 		steps.And("the modified chart is written")
+		steps.And("the location of the chart is shown")
 	})
 
 	steps.Define(func(define Definitions) {
@@ -80,19 +82,34 @@ var _ = Describe("External tests", func() {
 		})
 
 		define.Then(`^the command says that the rewritten image will be pushed$`, func() {
-			Eventually(CommandSession.Out, time.Minute).Should(Say("Image moves:"))
+			Eventually(CommandSession.Out, time.Minute).Should(Say("Image copies:"))
 			Eventually(CommandSession.Out).Should(Say(fmt.Sprintf("harbor-repo.vmware.com/tanzu_isv_engineering/tiny:tiniest => harbor-repo.vmware.com/%s/tiny:tiniest \\(sha256:[a-z0-9]*\\) \\(push required\\)", customRepoPrefix)))
 		})
 
-		define.Then(`^the command says that the rewritten images will be written to the chart$`, func() {
-			Eventually(CommandSession.Out).Should(Say("Changes written to testchart/values.yaml:"))
+		define.Then(`^the command says that the rewritten images will be written to the chart and subchart$`, func() {
+			Eventually(CommandSession.Out).Should(Say("Changes to be applied to testchart/values.yaml:"))
 			Eventually(CommandSession.Out).Should(Say(fmt.Sprintf("  .image.repository: harbor-repo.vmware.com/%s/tiny", customRepoPrefix)))
 			Eventually(CommandSession.Out).Should(Say(fmt.Sprintf("  .sameImageButNoTagRequirement.image: harbor-repo.vmware.com/%s/tiny@sha256:[a-z0-9]*", customRepoPrefix)))
 			Eventually(CommandSession.Out).Should(Say(fmt.Sprintf("  .singleImageReference.image: harbor-repo.vmware.com/%s/busybox@sha256:[a-z0-9]*", customRepoPrefix)))
+			// Subchart
+			Eventually(CommandSession.Out).Should(Say("Changes to be applied to testchart/charts/subchart/values.yaml:"))
+			Eventually(CommandSession.Out).Should(Say(fmt.Sprintf("  .image.name: harbor-repo.vmware.com/%s/tiny", customRepoPrefix)))
 		})
 
 		define.Then(`^the rewritten image is pushed$`, func() {
 			Eventually(CommandSession.Out).Should(Say(fmt.Sprintf("Pushing harbor-repo.vmware.com/%s/tiny:tiniest...\nDone", customRepoPrefix)))
+		})
+
+		define.Then(`^the chart name and version is shown before relocation$`, func() {
+			Eventually(CommandSession.Out).Should(Say("Relocating testchart@0.1.0..."))
+		})
+
+		define.Then(`^the location of the chart is shown$`, func() {
+			cwd, err := os.Getwd()
+			Expect(err).ToNot(HaveOccurred())
+			modifiedChartPath := filepath.Join(cwd, "testchart-0.1.0.relocated.tgz")
+
+			Eventually(CommandSession.Out).Should(Say(modifiedChartPath))
 		})
 
 		var modifiedChartPath string
@@ -105,6 +122,12 @@ var _ = Describe("External tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(modifiedChart.Values["image"]).To(HaveKeyWithValue("repository", fmt.Sprintf("harbor-repo.vmware.com/%s/tiny", customRepoPrefix)))
+			// Subchart was rewritten too
+			for _, subchart := range modifiedChart.Dependencies() {
+				if subchart.Name() == "subchart" {
+					Expect(subchart.Values["image"]).To(HaveKeyWithValue("name", fmt.Sprintf("harbor-repo.vmware.com/%s/tiny", customRepoPrefix)))
+				}
+			}
 
 			imageMap, ok := modifiedChart.Values["sameImageButNoTagRequirement"].(map[string]interface{})
 			Expect(ok).To(BeTrue())

--- a/test/fixtures/testchart.images.yaml
+++ b/test/fixtures/testchart.images.yaml
@@ -2,3 +2,5 @@
 - "{{ .image.repository }}:{{ .image.tag }}"
 - "{{ .sameImageButNoTagRequirement.image }}"
 - "{{ .singleImageReference.image }}"
+# Subchart
+- "{{ .subchart.image.name }}:{{ .subchart.image.tag }}"

--- a/test/fixtures/testchart/charts/subchart/.helmignore
+++ b/test/fixtures/testchart/charts/subchart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/test/fixtures/testchart/charts/subchart/Chart.yaml
+++ b/test/fixtures/testchart/charts/subchart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: subchart
+description: A subchart for testing relok8s
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/test/fixtures/testchart/charts/subchart/values.yaml
+++ b/test/fixtures/testchart/charts/subchart/values.yaml
@@ -1,0 +1,3 @@
+image:
+  name: harbor-repo.vmware.com/tanzu_isv_engineering/tiny
+  tag: tiniest


### PR DESCRIPTION
Some minor tweaks in the output based on my experience using the tool. 

They could be summarized as

* Standardize on future tense. Fixes https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/issues/34
* Removes chart path from the rewrite `path` shown to the user. Fixes https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/issues/38
* Show location of the final file
* Indicate explicitly if an image exists
* Move some of the logging capabilities inside the library so other consumers can also get debugging information
* Remove some redundant information

Example output

```
 go run main.go chart move --image-patterns examples/chart-with-subcharts/image-hints.yaml --registry projects.registry.vmware.com --repo-prefix relocated/example2 examples/chart-with-subcharts/wordpress-chart/
Computing relocation...

Image copies:
 index.docker.io/bitnami/wordpress:5.7.2-debian-10-r45 => projects.registry.vmware.com/relocated/example2/wordpress:5.7.2-debian-10-r45 (sha256:187d539c69e4da11706d63fead255a870cae79a34719b67f8d1cbfd8f7653ff8) (already exists)
 index.docker.io/bitnami/apache-exporter:0.9.0-debian-10-r33 => projects.registry.vmware.com/relocated/example2/apache-exporter:0.9.0-debian-10-r33 (sha256:c64fa482ae9cbadbb53487d1155a0a135141116bbfecd8fded0cd365f9646407) (already exists)
 index.docker.io/bitnami/bitnami-shell:10-debian-10-r134 => projects.registry.vmware.com/relocated/example2/bitnami-shell:10-debian-10-r134 (sha256:1d385c55c7d8efddc1ac7c9a1d847e3b040803b8bcbf58fba41715e77706add7) (already exists)
 index.docker.io/bitnami/mariadb:10.5.11-debian-10-r0 => projects.registry.vmware.com/relocated/example2/mariadb:10.5.11-debian-10-r0 (sha256:160902dddb9c7d9640dcfc33ae0dbbed9346f786eeb653fa1b427c76f4673126) (already exists)
 index.docker.io/bitnami/mysqld-exporter:0.13.0-debian-10-r19 => projects.registry.vmware.com/relocated/example2/mysqld-exporter:0.13.0-debian-10-r19 (sha256:ad0993ebdf34a6b6ee0ec469384a3c92ed020ff7b23277c90d150ddd4ed01020) (already exists)
 index.docker.io/bitnami/bitnami-shell:10-debian-10-r115 => projects.registry.vmware.com/relocated/example2/bitnami-shell:10-debian-10-r115 (sha256:400d6b412a753845c65c656b311a1d032b605cf1c63e14c25929c1d9e9c423c8) (already exists)
 index.docker.io/bitnami/memcached:1.6.9-debian-10-r194 => projects.registry.vmware.com/relocated/example2/memcached:1.6.9-debian-10-r194 (sha256:3dcf3a49f162f55ae9f7407d022ae53021cccf49f8d43276080708bd56857e78) (already exists)
 index.docker.io/bitnami/memcached-exporter:0.9.0-debian-10-r85 => projects.registry.vmware.com/relocated/example2/memcached-exporter:0.9.0-debian-10-r85 (sha256:979154c8afa2027194fe2721351b112d4daacf96ccf6ff853525e4794d1bbe49) (already exists)
 index.docker.io/bitnami/bitnami-shell:10-debian-10-r120 => projects.registry.vmware.com/relocated/example2/bitnami-shell:10-debian-10-r120 (sha256:9eeeefd2e9abeed0ee111a43e4c5c19b2983b74a2a38adb641649a77929ac59b) (already exists)

Changes to be applied to wordpress/values.yaml:
  .image.registry: projects.registry.vmware.com
  .image.repository: relocated/example2/wordpress
  .metrics.image.registry: projects.registry.vmware.com
  .metrics.image.repository: relocated/example2/apache-exporter
  .volumePermissions.image.registry: projects.registry.vmware.com
  .volumePermissions.image.repository: relocated/example2/bitnami-shell

Changes to be applied to wordpress/charts/mariadb/values.yaml:
  .image.registry: projects.registry.vmware.com
  .image.repository: relocated/example2/mariadb
  .metrics.image.registry: projects.registry.vmware.com
  .metrics.image.repository: relocated/example2/mysqld-exporter
  .volumePermissions.image.registry: projects.registry.vmware.com
  .volumePermissions.image.repository: relocated/example2/bitnami-shell

Changes to be applied to wordpress/charts/memcached/values.yaml:
  .image.registry: projects.registry.vmware.com
  .image.repository: relocated/example2/memcached
  .metrics.image.registry: projects.registry.vmware.com
  .metrics.image.repository: relocated/example2/memcached-exporter
  .volumePermissions.image.registry: projects.registry.vmware.com
  .volumePermissions.image.repository: relocated/example2/bitnami-shell
Would you like to proceed? (y/N)
y
Relocating wordpress@11.1.5...
Done
/home/migmartri/relok8s/wordpress-11.1.5.relocated.tgz
```

Part of https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/37

Signed-off-by: Miguel Martinez Trivino <mtrivino@vmware.com>