### PR TITLE
chore: remove /v2 from module path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ deps: vendor/modules.txt deps-goimports deps-counterfeiter deps-ginkgo
 
 SRC = $(shell find . -name "*.go" | grep -v "_test\." )
 VERSION := $(or $(VERSION), dev)
-LDFLAGS="-X github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/cmd.Version=$(VERSION)"
+LDFLAGS="-X github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/cmd.Version=$(VERSION)"
 
 build/relok8s: $(SRC)
 	go build -o build/relok8s -ldflags ${LDFLAGS} ./main.go

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Building the tool from source is very simple with:
 
 ```bash
 $ make build
-go build -o build/relok8s -ldflags "-X github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/cmd.Version=dev" ./main.go
+go build -o build/relok8s -ldflags "-X github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/cmd.Version=dev" ./main.go
 pwall@pwall-a01:~/src/vmware-tanzu/asset-relocation-tool-for-kubernetes $ ls ./build/relok8s 
 ./build/relok8s
 ```

--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/pkg/mover"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pkg/mover"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2
+module github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes
 
 go 1.16
 

--- a/internal/image_template_test.go
+++ b/internal/image_template_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/internal"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/test"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/test"
 )
 
 var _ = Describe("internal.NewFromString", func() {

--- a/internal/internalfakes/fake_image_interface.go
+++ b/internal/internalfakes/fake_image_interface.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/internal"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal"
 )
 
 type FakeImageInterface struct {

--- a/internal/rewrite_action.go
+++ b/internal/rewrite_action.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/divideandconquer/go-merge/merge"
 	"github.com/google/go-containerregistry/pkg/name"
-	yamlops2 "github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/internal/yamlops"
+	yamlops2 "github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal/yamlops"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 )

--- a/internal/rewrite_action_test.go
+++ b/internal/rewrite_action_test.go
@@ -6,7 +6,7 @@ package internal_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/internal"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal"
 )
 
 var _ = Describe("RewriteAction", func() {

--- a/internal/yamlops/nodesearch_test.go
+++ b/internal/yamlops/nodesearch_test.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"testing"
 
-	yamlops2 "github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/internal/yamlops"
+	yamlops2 "github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal/yamlops"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/yamlops/scanner_test.go
+++ b/internal/yamlops/scanner_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	yamlops2 "github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/internal/yamlops"
+	yamlops2 "github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal/yamlops"
 )
 
 type node struct {

--- a/internal/yamlops/yamlops_test.go
+++ b/internal/yamlops/yamlops_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	yamlops2 "github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/internal/yamlops"
+	yamlops2 "github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal/yamlops"
 )
 
 func TestUpdateMap(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/cmd"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/cmd"
 )
 
 func main() {

--- a/pkg/mover/chart.go
+++ b/pkg/mover/chart.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 
 	"github.com/avast/retry-go"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/internal"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"

--- a/pkg/mover/chart_test.go
+++ b/pkg/mover/chart_test.go
@@ -14,10 +14,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/internal"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/internal/internalfakes"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/pkg/mover/moverfakes"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/test"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal/internalfakes"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pkg/mover/moverfakes"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/test"
 	"helm.sh/helm/v3/pkg/chart/loader"
 )
 

--- a/test/chart_move_feature_test.go
+++ b/test/chart_move_feature_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/test"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/test"
 )
 
 var _ = Describe("relok8s chart move command", func() {

--- a/test/common_steps.go
+++ b/test/common_steps.go
@@ -25,9 +25,9 @@ var (
 var _ = ginkgo.BeforeSuite(func() {
 	var err error
 	ChartMoverBinaryPath, err = gexec.Build(
-		"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2",
+		"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes",
 		"-ldflags",
-		"-X github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/v2/cmd.Version=1.2.3",
+		"-X github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/cmd.Version=1.2.3",
 	)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })


### PR DESCRIPTION
Refs https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/issues/54

Removed the major version namespace in the module name. We have never had a v1 so a v2 from the get go does not make much sense.