### PR TITLE
Switch to golangci-lint instead of goimports and run in Concourse pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ default: build
 
 
 # #### GO Binary Management ####
-.PHONY: deps-go-binary deps-goimports deps-counterfeiter deps-ginkgo
+.PHONY: deps-go-binary deps-counterfeiter deps-ginkgo deps-golangci-lint
 
 GO_VERSION := $(shell go version)
 GO_VERSION_REQUIRED = go1.16
@@ -24,16 +24,10 @@ endif
 
 HAS_COUNTERFEITER := $(shell command -v counterfeiter;)
 HAS_GINKGO := $(shell command -v ginkgo;)
-HAS_GO_IMPORTS := $(shell command -v goimports;)
 HAS_GOLANGCI_LINT := $(shell command -v golangci-lint;)
 
 # If go get is run from inside the project directory it will add the dependencies
 # to the go.mod file. To avoid that we import from another directory
-deps-goimports: deps-go-binary
-ifndef HAS_GO_IMPORTS
-	cd /; go get -u golang.org/x/tools/cmd/goimports
-endif
-
 deps-counterfeiter: deps-go-binary
 ifndef HAS_COUNTERFEITER
 	cd /; go get -u github.com/maxbrunsfeld/counterfeiter/v6
@@ -44,7 +38,7 @@ ifndef HAS_GINKGO
 	cd /; go get github.com/onsi/ginkgo/ginkgo github.com/onsi/gomega
 endif
 
-deps-golangci-lint: deps-go-binary deps-goimports
+deps-golangci-lint: deps-go-binary
 ifndef HAS_GOLANGCI_LINT
 	cd /; go get github.com/golangci/golangci-lint/cmd/golangci-lint
 endif
@@ -62,7 +56,7 @@ clean: deps-go-binary
 vendor/modules.txt: go.mod
 	go mod vendor
 
-deps: vendor/modules.txt deps-goimports deps-counterfeiter deps-ginkgo
+deps: vendor/modules.txt deps-counterfeiter deps-ginkgo
 
 
 # #### BUILD ####

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -8,10 +8,13 @@ WORKDIR /
 RUN yum -y install build-essential coreutils gawk gcc git go jq make
 ENV PATH="/root/go/bin:${PATH}"
 
+ARG GOLANGCI_LINT_VERSION="v1.42.0"
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+
 # Install go packages used for building and testing
-RUN go get -u golang.org/x/tools/cmd/goimports \
-    github.com/maxbrunsfeld/counterfeiter/v6 \
-    github.com/onsi/ginkgo/ginkgo github.com/onsi/gomega
+RUN go get -u github.com/maxbrunsfeld/counterfeiter/v6 \
+    github.com/onsi/ginkgo/ginkgo \
+    github.com/onsi/gomega
 
 # Install Helm
 RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -110,6 +110,11 @@ jobs:
             trigger: true
           - get: source
             trigger: true
+      - task: run-lint
+        image: test-image
+        file: source/ci/tasks/test.yaml
+        params:
+          MAKE_TARGET: lint
       - task: run-unit-tests
         image: test-image
         file: source/ci/tasks/test.yaml
@@ -278,6 +283,11 @@ jobs:
               context: merge-conflict
               status: failure
       - do:
+        - task: run-lint
+          image: test-image
+          file: source/ci/tasks/test.yaml
+          params:
+            MAKE_TARGET: lint
         - task: run-unit-tests
           image: test-image
           file: source/ci/tasks/test.yaml


### PR DESCRIPTION
I recognize that this works in golang actions, but I appreciate having it in both. Also, it removes the dependency on goimports in the makefile.