### PR TITLE
fix: rewrite only registry

### DIFF
--- a/internal/internal_suite_test.go
+++ b/internal/internal_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package internal_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal Suite")
+}


### PR DESCRIPTION
Fixes a regression introduced here https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/42. The issue is that the template/rewrite systems does not react properly in the case where the template has both the registry and the path but only the registry is provided.

This PR requires additional testing, @petewall feel free to own this PR and thanks for reporting it!