### PR TITLE
Support using sub charts with dashes in a user-friendly way

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,18 @@ It can contain dependent charts.
 
 ### Image Patterns File
 
-The Asset Relocation Tool for Kubernetes requires an image patterns file. This file determines the list of images encoded in the helm chart.
+The Asset Relocation Tool for Kubernetes requires an image patterns file.
+This file determines the list of images encoded in the Helm chart.
 
 ```yaml
 ---
 - "{{ .image }}:{{ .tag }}",
 - "{{ .proxy.image }}:{{ .proxy.tag }}",
+- "{{ .dependent-chart.image.repository }}@{{ .dependent-chart.image.digest }}",
 ```
 
-This file is a list of strings, which can be evaluated like a template to reference the fully detailed image path.
+This file is a list of strings which reference the fully detailed image path.
+To reference images encoded inside a dependent chart, the first key should be the dependent chart's name.
 
 ### Rules
 

--- a/internal/image_template.go
+++ b/internal/image_template.go
@@ -6,6 +6,7 @@ package internal
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"text/template"
 
 	"gopkg.in/yaml.v2"
@@ -33,8 +34,25 @@ func (t *ImageTemplate) String() string {
 	return t.Raw
 }
 
+func prepTemplateString(input string) string {
+	output := ""
+	matches := TemplateRegex.FindAllStringSubmatchIndex(input, -1)
+	start := 0
+	for _, match := range matches {
+		output += input[start:match[2]] + "index ."
+		parts := strings.Split(input[match[2]+1:match[3]], ".")
+		for _, part := range parts {
+			output += " \"" + part + "\""
+		}
+		start = match[3]
+	}
+	output += input[start:]
+	return output
+}
+
 func NewFromString(input string) (*ImageTemplate, error) {
-	temp, err := template.New(input).Parse(input)
+	preppedInput := prepTemplateString(input)
+	temp, err := template.New(preppedInput).Parse(preppedInput)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image template \"%s\": %w", input, err)
 	}

--- a/internal/rewrite_action.go
+++ b/internal/rewrite_action.go
@@ -118,13 +118,17 @@ func GetChartValues(chart *chart.Chart) (int, []byte) {
 type ValuesMap map[string]interface{}
 
 func BuildValuesMap(chart *chart.Chart, rewriteActions []*RewriteAction) map[string]interface{} {
+	values := chart.Values
+	if values == nil {
+		values = map[string]interface{}{}
+	}
+
 	// Add values for chart dependencies
 	for _, dependency := range chart.Dependencies() {
-		chart.Values[dependency.Name()] = merge.Merge(dependency.Values, chart.Values[dependency.Name()])
+		values[dependency.Name()] = merge.Merge(dependency.Values, values[dependency.Name()])
 	}
 
 	// Apply rewrite actions
-	values := chart.Values
 	for _, action := range rewriteActions {
 		actionMap := action.ToMap()
 		result := merge.Merge(values, actionMap)

--- a/pkg/mover/chart_test.go
+++ b/pkg/mover/chart_test.go
@@ -439,8 +439,26 @@ const (
 	fixturesRoot = "../../test/fixtures/"
 )
 
+type FakeLogger struct {
+	Output *Buffer
+}
+
+func (l *FakeLogger) Printf(format string, i ...interface{}) {
+	_, _ = fmt.Fprintf(l.Output, format, i...)
+}
+
+func (l *FakeLogger) Println(i ...interface{}) {
+	_, _ = fmt.Fprintln(l.Output, i...)
+}
+
 var _ = Describe("LoadImagePatterns", func() {
-	logger := &defaultLogger{}
+	var logger *FakeLogger
+
+	BeforeEach(func() {
+		logger = &FakeLogger{
+			Output: NewBuffer(),
+		}
+	})
 
 	It("reads from given file first if present", func() {
 		imagefile := filepath.Join(fixturesRoot, "testchart.images.yaml")
@@ -462,6 +480,8 @@ var _ = Describe("LoadImagePatterns", func() {
 		expected, err := os.ReadFile(embeddedPatterns)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(contents).To(Equal(expected))
+
+		Expect(logger.Output).Should(Say(".relok8s-images.yaml hints file found"))
 	})
 	It("reads nothing when no file and the chart is not self relok8able", func() {
 		chart, err := loader.Load(filepath.Join(fixturesRoot, "testchart"))


### PR DESCRIPTION
This translates the image pattern template internally to always use the `{{ index . \"key1\" \"key2\" }}` format, allowing us to support subcharts with dashes.

Signed-off-by: Pete Wall <pwall@vmware.com>