### PR TITLE
Fix apply method and apply default hash

### DIFF
--- a/internal/internal_suite_test.go
+++ b/internal/internal_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package internal_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal Suite")
+}

--- a/pkg/mover/chart.go
+++ b/pkg/mover/chart.go
@@ -261,10 +261,9 @@ func computeChanges(chart *chart.Chart, imageChanges []*internal.ImageChange, re
 		rewriteRules := &internal.OCIImageLocation{
 			Registry:         registryRules.Registry,
 			RepositoryPrefix: registryRules.RepositoryPrefix,
-			Digest:           change.Digest,
 		}
 
-		newActions, err := change.Pattern.Apply(change.ImageReference, rewriteRules)
+		newActions, err := change.Pattern.Apply(change.ImageReference.Context(), change.Digest, rewriteRules)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Supersedes https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/63

This patch does the following

- Fixes
  - Adds a test-suite file to make sure that those unit tests are run, thanks @petewall for the catch
  - Fixes a regression in which we were adding rewrite rules even if it's value was the same and in practice meant a no-op
  - Fixes a regression in where if only the registry rule was passed and the template was registry+path, the rewrite was not working as expected. 

- Cleanup
  - It removes the `Digest` property from the Apply Rewrite rules inputs since we do not allow rewriting it at this point and it was confusing. Currently the only rewrite sources are the repoPrefix and the registry

- Feature 
  - By default we try to add the content digest to the image path unless explicitly specified by the user via @digest or :tag templates. I am not sure when this feature got dropped, at least in our initial POCs we were doing it. I have updated the tests accordingly