### PR TITLE
Lint improvements

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,32 +2,28 @@ run:
   timeout: 10m
 
 linters:
-  disable-all: true
   enable:
-    - goheader
     - deadcode
     - dupl
     - gofmt
+    - goheader
     - goimports
     # golint replacement
-    - revive
     - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
+    - revive
+    - staticcheck
     - structcheck
     - unused
     - varcheck
-    - staticcheck
-    
+
 linters-settings:
   gofmt:
     simplify: true
   dupl:
     threshold: 400
   goheader:
-    values:
-      regexp:
-        copyright-year: 2021
     template-path: code-header-template.txt

--- a/code-header-template.txt
+++ b/code-header-template.txt
@@ -1,2 +1,2 @@
-Copyright {{copyright-year}} VMware, Inc.
+Copyright {{YEAR}} VMware, Inc.
 SPDX-License-Identifier: BSD-2-Clause

--- a/pkg/mover/doc_test.go
+++ b/pkg/mover/doc_test.go
@@ -40,5 +40,9 @@ func Example() {
 	// i.e ./mariadb-7.5.relocated.tgz
 	destinationPath := fmt.Sprintf("./%s-%s.relocated.tgz", chartMetadata.Name, chartMetadata.Version)
 	// Perform the push, rewrite and repackage of the Helm Chart
-	chartMover.Move(destinationPath)
+	err = chartMover.Move(destinationPath)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 }


### PR DESCRIPTION
* Re-enabled default linters
* Alphabatized enabled linter list
* Removed custom year argument in favor of one that is pre-provided by goheader
* Fixed a singular issue from the new linter rules

Signed-off-by: Pete Wall <pwall@vmware.com>