### PR TITLE
Validate registry and repository prefix user inputs

### DIFF
--- a/pkg/mover/chart.go
+++ b/pkg/mover/chart.go
@@ -44,14 +44,6 @@ func (e *ChartLoadingError) Unwrap() error {
 	return e.Inner
 }
 
-// RewriteRules indicate What kind of target registry overrides we want to apply to the found images
-type RewriteRules struct {
-	// Registry overrides the registry part of the image FQDN, i.e myregistry.io
-	Registry string
-	// RepositoryPrefix will override the image path by being prepended before the image name
-	RepositoryPrefix string
-}
-
 // Logger represents an interface used to output moving information
 type Logger interface {
 	Printf(format string, i ...interface{})

--- a/pkg/mover/rewrite_rules.go
+++ b/pkg/mover/rewrite_rules.go
@@ -1,0 +1,36 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package mover
+
+import (
+	"errors"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+// RewriteRules indicate What kind of target registry overrides we want to apply to the found images
+type RewriteRules struct {
+	// Registry overrides the registry part of the image FQDN, i.e myregistry.io
+	Registry string
+	// RepositoryPrefix will override the image path by being prepended before the image name
+	RepositoryPrefix string
+}
+
+func (r *RewriteRules) Validate() error {
+	if r.Registry != "" {
+		_, err := name.NewRegistry(r.Registry, name.StrictValidation)
+		if err != nil {
+			return errors.New("registry rule is not valid")
+		}
+	}
+
+	if r.RepositoryPrefix != "" {
+		_, err := name.NewRepository(r.RepositoryPrefix)
+		if err != nil {
+			return errors.New("repository prefix is not valid")
+		}
+	}
+
+	return nil
+}

--- a/pkg/mover/rewrite_rules_test.go
+++ b/pkg/mover/rewrite_rules_test.go
@@ -1,0 +1,85 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package mover_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pkg/mover"
+)
+
+var _ = Describe("RewriteRules", func() {
+	Context("no rules", func() {
+		It("returns no error", func() {
+			rules := mover.RewriteRules{}
+			err := rules.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("valid registry", func() {
+		It("returns no error", func() {
+			rules := mover.RewriteRules{
+				Registry: "projects.vmware.com",
+			}
+			err := rules.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("valid repository prefix", func() {
+		It("returns no error", func() {
+			rules := mover.RewriteRules{
+				RepositoryPrefix: "myprojects/subfolder",
+			}
+			err := rules.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("valid registry and repository prefix", func() {
+		It("returns no error", func() {
+			rules := mover.RewriteRules{
+				Registry:         "projects.vmware.com",
+				RepositoryPrefix: "myprojects/subfolder",
+			}
+			err := rules.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("invalid registry", func() {
+		It("returns no error", func() {
+			rules := mover.RewriteRules{
+				Registry: "a host with spaces",
+			}
+			err := rules.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("registry rule is not valid"))
+		})
+	})
+
+	Context("invalid repository prefix", func() {
+		It("returns no error", func() {
+			rules := mover.RewriteRules{
+				RepositoryPrefix: "repositories/cannot/contain+plusses",
+			}
+			err := rules.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("repository prefix is not valid"))
+		})
+	})
+
+	Context("invalid registry and repository prefix", func() {
+		It("returns no error", func() {
+			rules := mover.RewriteRules{
+				Registry:         "a.domain.with.an.invalid.port:lolwut",
+				RepositoryPrefix: "these#symbols&aren't@allowed",
+			}
+			err := rules.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("registry rule is not valid"))
+		})
+	})
+})

--- a/test/features/chart_move_feature_test.go
+++ b/test/features/chart_move_feature_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/test"
 )
 
-var _ = Describe("relok8s chart move command", func() {
+var _ = XDescribe("relok8s chart move command", func() {
 	steps := NewSteps()
 
 	// TODO: Excluding these scenarios until we have a fake docker daemon
@@ -47,63 +47,8 @@ var _ = Describe("relok8s chart move command", func() {
 		steps.Then("the command exits without error")
 	})
 
-	Scenario("missing helm chart", func() {
-		steps.When("running relok8s chart move")
-		steps.Then("the command exits with an error")
-		steps.And("it says the chart is missing")
-		steps.And("it prints the usage")
-	})
-
-	Scenario("helm chart does not exist", func() {
-		steps.When("running relok8s chart move ../fixtures/does-not-exist")
-		steps.Then("the command exits with an error")
-		steps.And("it says the chart does not exist")
-		steps.And("it prints the usage")
-	})
-
-	Scenario("helm chart is empty directory", func() {
-		steps.When("running relok8s chart move ../fixtures/empty-directory")
-		steps.Then("the command exits with an error")
-		steps.And("it says the chart is missing a critical file")
-		steps.And("it prints the usage")
-	})
-
-	Scenario("missing image patterns file", func() {
-		steps.When("running relok8s chart move ../fixtures/wordpress-11.0.4.tgz --repo-prefix cyberdyne-corp")
-		steps.Then("the command exits with an error")
-		steps.And("it says the image patterns file is missing")
-		steps.And("it prints the usage")
-	})
-
-	Scenario("no rules are given", func() {
-		steps.When("running relok8s chart move ../fixtures/wordpress-11.0.4.tgz --image-patterns ../fixtures/wordpress-11.0.4.images.yaml")
-		steps.Then("the command exits with an error")
-		steps.And("it says that the rules are missing")
-		steps.And("it prints the usage")
-	})
-
 	steps.Define(func(define Definitions) {
 		test.DefineCommonSteps(define)
-
-		define.Then(`^it says the chart is missing$`, func() {
-			Expect(test.CommandSession.Err).To(Say("Error: requires a chart argument"))
-		})
-
-		define.Then(`^it says the chart does not exist$`, func() {
-			Expect(test.CommandSession.Err).To(Say("Error: failed to load Helm Chart at \"../fixtures/does-not-exist\": stat ../fixtures/does-not-exist: no such file or directory"))
-		})
-
-		define.Then(`^it says the chart is missing a critical file$`, func() {
-			Expect(test.CommandSession.Err).To(Say("Error: failed to load Helm Chart at \"../fixtures/empty-directory\": Chart.yaml file is missing"))
-		})
-
-		define.Then(`^it says the image patterns file is missing$`, func() {
-			Expect(test.CommandSession.Err).To(Say("Error: image patterns file is required. Please try again with '--image-patterns <image patterns file>'"))
-		})
-
-		define.Then(`^it says that the rules are missing$`, func() {
-			Expect(test.CommandSession.Err).To(Say("Error: at least one rewrite rule must be given. Please try again with --registry and/or --repo-prefix"))
-		})
 
 		define.Then(`^the original images are pulled$`, func() {
 			Eventually(test.CommandSession.Out, time.Minute).Should(Say("Pulling docker.io/bitnami/wordpress:5.7.2-debian-10-r0... Done"))

--- a/test/features/chart_move_input_validation_feature_test.go
+++ b/test/features/chart_move_input_validation_feature_test.go
@@ -1,0 +1,115 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package features_test
+
+import (
+	. "github.com/bunniesandbeatings/goerkin"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/test"
+)
+
+var _ = Describe("relok8s chart move input validation", func() {
+	steps := NewSteps()
+
+	Scenario("missing helm chart", func() {
+		steps.When("running relok8s chart move")
+		steps.Then("the command exits with an error")
+		steps.And("it says the chart is missing")
+		steps.And("it prints the usage")
+	})
+
+	Scenario("helm chart does not exist", func() {
+		steps.When("running relok8s chart move ../fixtures/does-not-exist")
+		steps.Then("the command exits with an error")
+		steps.And("it says the chart does not exist")
+		steps.And("it prints the usage")
+	})
+
+	Scenario("helm chart is empty directory", func() {
+		steps.When("running relok8s chart move ../fixtures/empty-directory")
+		steps.Then("the command exits with an error")
+		steps.And("it says the chart is missing a critical file")
+		steps.And("it prints the usage")
+	})
+
+	Scenario("missing image patterns file", func() {
+		steps.When("running relok8s chart move ../fixtures/wordpress-11.0.4.tgz --repo-prefix cyberdyne-corp")
+		steps.Then("the command exits with an error")
+		steps.And("it says the image patterns file is missing")
+		steps.And("it prints the usage")
+	})
+
+	Scenario("too many arguments", func() {
+		steps.When("running relok8s chart move ../fixtures/wordpress-11.0.4.tgz --repo-prefix cyberdyne-corp")
+		steps.Then("the command exits with an error")
+		steps.And("it says the image patterns file is missing")
+		steps.And("it prints the usage")
+	})
+
+	Scenario("no rules are given", func() {
+		steps.When("running relok8s chart move ../fixtures/wordpress-11.0.4.tgz --image-patterns ../fixtures/wordpress-11.0.4.images.yaml --registry reg.vmware.com extra arguments")
+		steps.Then("the command exits with an error")
+		steps.And("it says that there are too many args")
+		steps.And("it prints the usage")
+	})
+
+	Scenario("no rules are given", func() {
+		steps.When("running relok8s chart move ../fixtures/wordpress-11.0.4.tgz --image-patterns ../fixtures/wordpress-11.0.4.images.yaml")
+		steps.Then("the command exits with an error")
+		steps.And("it says that the rules are missing")
+		steps.And("it prints the usage")
+	})
+
+	Scenario("invalid registry", func() {
+		steps.When("running relok8s chart move ../fixtures/wordpress-11.0.4.tgz --image-patterns ../fixtures/wordpress-11.0.4.images.yaml --registry what:is:this?")
+		steps.Then("the command exits with an error")
+		steps.And("it says that the registry is invalid")
+		steps.And("it prints the usage")
+	})
+
+	Scenario("invalid repo prefix", func() {
+		steps.When("running relok8s chart move ../fixtures/wordpress-11.0.4.tgz --image-patterns ../fixtures/wordpress-11.0.4.images.yaml --repo-prefix 'What+is$this???'")
+		steps.Then("the command exits with an error")
+		steps.And("it says that the repository prefix is invalid")
+		steps.And("it prints the usage")
+	})
+
+	steps.Define(func(define Definitions) {
+		test.DefineCommonSteps(define)
+
+		define.Then(`^it says the chart is missing$`, func() {
+			Expect(test.CommandSession.Err).To(Say("Error: requires a chart argument"))
+		})
+
+		define.Then(`^it says the chart does not exist$`, func() {
+			Expect(test.CommandSession.Err).To(Say("Error: failed to load Helm Chart at \"../fixtures/does-not-exist\": stat ../fixtures/does-not-exist: no such file or directory"))
+		})
+
+		define.Then(`^it says the chart is missing a critical file$`, func() {
+			Expect(test.CommandSession.Err).To(Say("Error: failed to load Helm Chart at \"../fixtures/empty-directory\": Chart.yaml file is missing"))
+		})
+
+		define.Then(`^it says the image patterns file is missing$`, func() {
+			Expect(test.CommandSession.Err).To(Say("Error: image patterns file is required. Please try again with '--image-patterns <image patterns file>'"))
+		})
+
+		define.Then(`^it says that there are too many args$`, func() {
+			Expect(test.CommandSession.Err).To(Say(`expected 1 chart argument, received \d args`))
+		})
+
+		define.Then(`^it says that the rules are missing$`, func() {
+			Expect(test.CommandSession.Err).To(Say("Error: at least one rewrite rule must be given. Please try again with --registry and/or --repo-prefix"))
+		})
+
+		define.Then(`^it says that the registry is invalid$`, func() {
+			Expect(test.CommandSession.Err).To(Say("Error: registry rule is not valid"))
+		})
+
+		define.Then(`^it says that the repository prefix is invalid$`, func() {
+			Expect(test.CommandSession.Err).To(Say("Error: repository prefix is not valid"))
+		})
+	})
+})


### PR DESCRIPTION
This adds validation to the `--registry` and `--repo-prefix` parameters.

It splits the existing feature test into an input validation feature test and a chart move feature test (which is still disabled until I figure out a way to make a fake image registry to talk to).

Signed-off-by: Pete Wall <pwall@vmware.com>