### PR TITLE
Fix build issues

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -18,6 +18,14 @@ resource_types:
       username: ((harbor.username))
       password: ((harbor.token))
 
+  - name: github-release
+    type: docker-image
+    source:
+      repository: harbor-repo.vmware.com/dockerhub-proxy-cache/concourse/github-release-resource
+      tag: 1.6.4
+      username: ((harbor.username))
+      password: ((harbor.token))
+
 resources:
   - name: source
     type: git
@@ -163,7 +171,7 @@ jobs:
                 - build/*
         - do:
           - task: make-args-file
-            image: docker-image
+            image: test-image
             config:
               platform: linux
               inputs:
@@ -194,6 +202,7 @@ jobs:
                 - name: image
               params:
                 BUILD_ARGS_FILE: args-file/args.env
+                REGISTRY_MIRRORS: mirror.kokoni.info
               run:
                 path: build
           - put: docker-image


### PR DESCRIPTION
* mirror.kokoni.info implements a mirror for harbor-repo.vmware.com/dockerhub-proxy-cache, which allows us to keep the dockerhub image paths in the Dockerfile
* The GitHub release was stuck on a bug that was fixed in a newer version of the github-release-resource

Signed-off-by: Pete Wall <pwall@vmware.com>

Fixes #74 