### PR TITLE
Do not set user/group per file when tarring

### DIFF
--- a/pkg/mover/tar.go
+++ b/pkg/mover/tar.go
@@ -9,34 +9,9 @@ import (
 	"io"
 	"log"
 	"os"
-	"os/user"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"syscall"
 )
-
-func uname(info os.FileInfo) string {
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		u, err := user.LookupId(strconv.Itoa(int(stat.Uid)))
-		if err != nil {
-			log.Fatalf("Failed to get username for uid %v: %v", stat.Uid, err)
-		}
-		return u.Username
-	}
-	return ""
-}
-
-func gname(info os.FileInfo) string {
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		g, err := user.LookupGroupId(strconv.Itoa(int(stat.Gid)))
-		if err != nil {
-			log.Fatalf("Failed to get username for uid %v: %v", stat.Uid, err)
-		}
-		return g.Name
-	}
-	return ""
-}
 
 func tarDirectory(rootPath, tarFile string) error {
 	f, err := os.Create(tarFile)
@@ -58,8 +33,6 @@ func tarDirectory(rootPath, tarFile string) error {
 			Name:    name,
 			Mode:    int64(info.Mode()),
 			ModTime: info.ModTime(),
-			Uname:   uname(info),
-			Gname:   gname(info),
 		}
 		if info.IsDir() {
 			hdr.Typeflag = tar.TypeDir


### PR DESCRIPTION
Seems that even docker save does not set any user or group info per file to be set in the tar. When extracting they will be populated as per ownership of the running process, which is fine.

See context here:
https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/82#discussion_r756467402
and here:
https://gist.github.com/migmartri/06fcb75e4f9d88e1e310472ca5d672d2

Signed-off-by: Jose Luis Vazquez Gonzalez <josvaz@vmware.com>