### PR TITLE
Support load from flat archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ test-features: deps test-fixtures
 	ginkgo -r test/features
 
 test-external: deps test-fixtures
-	RELOK8S_EXPERIMENTAL=yes ginkgo -r test/external
+	ginkgo -r test/external
 
 test-registry: deps test
 	docker build -f test/registry/Dockerfile -t registry-tester .

--- a/pkg/mover/chart_test.go
+++ b/pkg/mover/chart_test.go
@@ -310,7 +310,7 @@ var _ = Describe("Pull & Push Images", func() {
 			}
 
 			cm := testChartMover(fakeRegistry, newLogger())
-			changes, err := cm.pullOriginalImages(patterns)
+			changes, err := cm.loadImages(patterns)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("pulling the images", func() {
@@ -342,7 +342,7 @@ var _ = Describe("Pull & Push Images", func() {
 				}
 
 				cm := testChartMover(fakeRegistry, newLogger())
-				changes, err := cm.pullOriginalImages(patterns)
+				changes, err := cm.loadImages(patterns)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("pulling the image once", func() {
@@ -370,9 +370,9 @@ var _ = Describe("Pull & Push Images", func() {
 				}
 
 				cm := testChartMover(fakeRegistry, newLogger())
-				_, err := cm.pullOriginalImages(patterns)
+				_, err := cm.loadImages(patterns)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("image pull error"))
+				Expect(err.Error()).To(Equal("failed to pull original images: image pull error"))
 			})
 		})
 	})

--- a/pkg/mover/intermediate.go
+++ b/pkg/mover/intermediate.go
@@ -4,16 +4,20 @@
 package mover
 
 import (
+	"archive/tar"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal"
+	"gopkg.in/yaml.v2"
 	"helm.sh/helm/v3/pkg/chart"
 )
 
@@ -103,4 +107,149 @@ func deduplicateByDigest(name string, current, previous v1.Image) error {
 			name, previousDigest, imageDigest)
 	}
 	return nil
+}
+
+// IsIntermediateBundle returns tue only if VerifyIntermediateBundle finds no errors
+func IsIntermediateBundle(bundlePath string) bool {
+	return VerifyIntermediateBundle(bundlePath) == nil
+}
+
+type fileValidations struct {
+	filename, format string
+	validate         func(io.Reader) error
+}
+
+func baseDir(path string) string {
+	separator := string(filepath.Separator)
+	dir := filepath.Dir(filepath.Clean(path))
+	elements := strings.Split(dir, separator)
+	baseDir := elements[0]
+	if len(elements) > 1 && baseDir == "" {
+		baseDir = separator + elements[1]
+	}
+	return baseDir
+}
+
+// VerifyIntermediateBundle returns true if the path points to an uncompressed
+// tarball with:
+// - A hints.yaml YAML file
+// - A manifest.json for the images
+// - A directory container an unpacked chart directory with valid YAMLs Chart.yaml & values.yaml
+func VerifyIntermediateBundle(bundlePath string) error {
+	chartDir, err := bundleChartDir(bundlePath)
+	if err != nil {
+		return err
+	}
+	validations := []fileValidations{
+		{filename: "hints.yaml", format: "YAML", validate: validateYAML},
+		{filename: "manifest.json", format: "JSON", validate: validateJSON},
+		{filename: fmt.Sprintf("%s/Chart.yaml", chartDir), format: "YAML", validate: validateYAML},
+		{filename: fmt.Sprintf("%s/values.yaml", chartDir), format: "YAML", validate: validateYAML},
+	}
+	for _, fv := range validations {
+		r, err := openFromTar(bundlePath, fv.filename)
+		if err != nil {
+			return fmt.Errorf("failed to open file %s from tar: %w", fv.filename, err)
+		}
+		defer r.Close()
+		if err := fv.validate(r); err != nil {
+			return fmt.Errorf("%w: %s is not valid %s: %v",
+				ErrNotIntermediateBundle, fv.filename, fv.format, err)
+		}
+	}
+	return nil
+}
+
+type intermediateBundle struct {
+	bundlePath string
+}
+
+func openBundle(bundlePath string) (*intermediateBundle, error) {
+	if err := VerifyIntermediateBundle(bundlePath); err != nil {
+		return nil, err
+	}
+	return &intermediateBundle{bundlePath}, nil
+}
+
+func bundleChartDir(bundlePath string) (string, error) {
+	chartDir := ""
+	err := tarList(bundlePath, func(hdr *tar.Header) error {
+		dir := baseDir(hdr.Name)
+		if dir != "." && dir != "/" {
+			chartDir = dir
+			return errEndOfList
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list tar %s: %w", bundlePath, err)
+	}
+	if chartDir == "" {
+		return "", fmt.Errorf("failed to find the chart folder in tar %s", bundlePath)
+	}
+	return chartDir, nil
+}
+
+func (ib *intermediateBundle) ExtractChartTo(dir string) error {
+	chartDir, err := bundleChartDir(ib.bundlePath)
+	if err != nil {
+		return fmt.Errorf("failed to detect chart directory from bundle %s: %w", ib.bundlePath, err)
+	}
+	err = untar(ib.bundlePath, chartDir, dir)
+	if err != nil {
+		return fmt.Errorf("failed to untar chart %s from bundle %s into %s: %w",
+			chartDir, ib.bundlePath, dir, err)
+	}
+	return nil
+}
+
+func (ib *intermediateBundle) LoadHints(log Logger) ([]byte, error) {
+	r, err := openFromTar(ib.bundlePath, HintsFilename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract %s from bundle at %s: %w",
+			HintsFilename, ib.bundlePath, err)
+	}
+	return io.ReadAll(r)
+}
+
+func refToTag(imageRef name.Reference) (name.Tag, error) {
+	// more often that not an name.Reference is actually backed by a name.Tag
+	if tag, ok := (imageRef).(name.Tag); ok {
+		return tag, nil
+	}
+	return name.NewTag(fmt.Sprintf("%s:%s", imageRef.Context().Name(), imageRef.Identifier()))
+}
+
+func (ib *intermediateBundle) LoadImage(imageRef name.Reference) (v1.Image, string, error) {
+	tag, err := refToTag(imageRef)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to make tag from %s: %w", imageRef.Name(), err)
+	}
+	image, err := tarball.ImageFromPath(ib.bundlePath, &tag)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to export image %s from tarball %s: %w", tag.Name(), ib.bundlePath, err)
+	}
+	digest, err := image.Digest()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get image digest for %s: %w", tag.Name(), err)
+	}
+	return image, digest.String(), nil
+}
+
+func validateYAML(r io.Reader) error {
+	yamlContents, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	var data interface{}
+	return yaml.Unmarshal(yamlContents, &data)
+}
+
+func validateJSON(r io.Reader) error {
+	jsonContents, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	var data interface{}
+	return json.Unmarshal(jsonContents, &data)
 }

--- a/pkg/mover/tar.go
+++ b/pkg/mover/tar.go
@@ -5,11 +5,20 @@ package mover
 
 import (
 	"archive/tar"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"log"
 	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	// errEndOfList tells a tar list loop to stop listing
+	errEndOfList = errors.New("end of list")
 )
 
 type tarFileWriter struct {
@@ -63,4 +72,117 @@ func reopenTarFileWriter(tarFile string) (*tarFileWriter, error) {
 		log.Fatalln(err)
 	}
 	return &tarFileWriter{Writer: tar.NewWriter(f), WriteCloser: f}, nil
+}
+
+func untar(tarFile, src, dst string) error {
+	f, err := os.Open(tarFile)
+	if err != nil {
+		return fmt.Errorf("failed to open tar file %s: %w", tarFile, err)
+	}
+	defer f.Close()
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil // End of archive
+		}
+		if err != nil {
+			return fmt.Errorf("failed to untar %s: %w", tarFile, err)
+		}
+		if src != "" && !strings.HasPrefix(hdr.Name, src) { // skip if not under src
+			continue
+		}
+		path := filepath.Join(dst, strings.TrimPrefix(hdr.Name, src))
+		if hdr.Typeflag == tar.TypeDir {
+			if err := os.MkdirAll(path, os.ModePerm); err != nil {
+				return fmt.Errorf("failed to extract directory %s: %w", path, err)
+			}
+			continue
+		}
+		dir := filepath.Dir(path)
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create extraction subdir %s: %w", dir, err)
+		}
+		f, err := os.Create(path)
+		if err != nil {
+			return fmt.Errorf("failed to extract file %s: %w", path, err)
+		}
+		if _, err := io.Copy(f, tr); err != nil {
+			return fmt.Errorf("failed extracting file %s: %w", path, err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("failed closing extracted file %s: %w", path, err)
+		}
+	}
+}
+
+// tarredFile represents a single file inside a tar. Closing it closes the tar itself.
+type tarredFile struct {
+	io.Reader
+	io.Closer
+}
+
+func openFromTar(tarFile, filePath string) (io.ReadCloser, error) {
+	f, err := os.Open(tarFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open tar file %s: %w", tarFile, err)
+	}
+	close := true
+	defer func() {
+		if close {
+			f.Close()
+		}
+	}()
+
+	tf := tar.NewReader(f)
+	for {
+		hdr, err := tf.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if hdr.Name == filePath {
+			if hdr.Typeflag == tar.TypeSymlink || hdr.Typeflag == tar.TypeLink {
+				currentDir := filepath.Dir(filePath)
+				return openFromTar(tarFile, path.Join(currentDir, hdr.Linkname))
+			}
+			close = false
+			return tarredFile{
+				Reader: tf,
+				Closer: f,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("file %s not found in tar", filePath)
+}
+
+type nextFn func(*tar.Header) error
+
+// tarList list all tar entries through the given next func, stops when the
+// end of the tar is reached or the next func returns errEndOfList
+func tarList(tarFile string, next nextFn) error {
+	f, err := os.Open(tarFile)
+	if err != nil {
+		return fmt.Errorf("failed to open tar file %s: %w", tarFile, err)
+	}
+	defer f.Close()
+	tf := tar.NewReader(f)
+	for {
+		hdr, err := tf.Next()
+		if errors.Is(err, io.EOF) || hdr == nil {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		err = next(hdr)
+		if err == errEndOfList {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
 }

--- a/test/external/external_test.go
+++ b/test/external/external_test.go
@@ -74,6 +74,21 @@ var _ = Describe("External tests", func() {
 		steps.Then("the command says the intermediate bundle is complete")
 	})
 
+	Scenario("running chart move from intermediate bundle", func() {
+		oldprefix := customRepoPrefix
+		customRepoPrefix += "-unbundled"
+		steps.When(fmt.Sprintf("running relok8s chart move -y ../fixtures/testchart-intermediate.tar --repo-prefix %s", customRepoPrefix))
+		steps.And("the move is computed")
+		steps.Then("the command says that the unbundled & rewritten image will be pushed")
+		steps.And("the command says that the rewritten images will be written to the chart and subchart")
+		steps.And("the command exits without error")
+		steps.And("the chart name and version is shown before relocation")
+		steps.And("the rewritten image is pushed")
+		steps.And("the modified chart is written")
+		steps.And("the location of the chart is shown")
+		customRepoPrefix = oldprefix
+	})
+
 	steps.Define(func(define Definitions) {
 		test.DefineCommonSteps(define)
 


### PR DESCRIPTION
**Expect major rebase damage due to changes in #98** 

Load of flat intermediate bundle tarball.

The airgap process implementation.

**load** step **is mostly on the NewChartMover() constructor**:

If a valid intermediate bundle tar is given, then:

1. Find the chart folder in the tar.
2. Extract the chart files only to a temporary dir.
3. Load the chart from the temporary chart dir and remove the dir.
4. Load the hints file from the tar directly.
5. Load the images directly off the tar, as the lib tarball already does by default.

Intermediate bundle operations:
- `IsIntermediateBundle` & `VerifyIntermediateBundle`: **Check if is is a bundle**and **validate a bundle for errors**. Allows to detect if the input given is a valid intermediate bundle.
- `openBundle`: checks and opens an intermediate bundle if valid. Returns a reference to load bits from the bundle:
  - `ExtractChartTo` to extract only the chart to a given directory, so that it can be loaded from extracted files.
  - `LoadHints` to load the hints file from the chart in memory.
  - `LoadImage` to load an image by name. Requires the bundle tar to be accesible while using the returned image, as the object uses the tar as backing storage.

Tar operations:
- `newTarFileWriter`: returns a tar file writer allowing the following operations:
  - `WriteFile` from memory into the next tar file entry.
  - `RawWriter` returns the tar file IO directly, allows to use a different tar writer for the following tar entries. This is required because we want the `tarball` lib to append images to an existing tar and it uses its own tar writer for doing that.
  - `Close` the tar file writer.
- `reopenTarFileWriter`: reopens an existing tar file allowing to append more entries. Although a `RawWriter` call would suffice to allow for appending to an open tar, we close and use this call to make it more explicit that we are appending.
- `untar`: allows to selectively extract a file or directory tree from the tar into a given location. It is used by the intermediate bundle to extract the chart files at load time.
- `openFromTar` opens a filename's stream directly from the tar file. Used to load the hints file or to perform tar file validations.
- `tarList` & `nextFn` are used by the intermediate bundle to list the tar contents to find the chart directory. Allows the intermediate bundle to extract only the chart files at load time.