### PR TITLE
Always push the tagged version, but write the digest version

### DIFF
--- a/internal/image_change.go
+++ b/internal/image_change.go
@@ -14,6 +14,7 @@ type ImageChange struct {
 	RewrittenReference name.Reference
 	Image              v1.Image
 	Digest             string
+	Tag                string
 	AlreadyPushed      bool
 }
 


### PR DESCRIPTION
If the original image is tagged, use that tag when pushing the resulting image, but still prefer to write the digest version to the Helm chart.

Closes #16 