### PR TITLE
Lighter registry test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,15 @@ test-features: deps test-fixtures
 test-external: deps test-fixtures
 	ginkgo -r test/external
 
-test-registry: deps test
+local-registry-image: deps test
 	docker build -f test/registry/Dockerfile -t registry-tester .
-	docker run -it --rm -p 5443:443 registry-tester
+
+test-registry: local-registry-image
+	docker run -it --rm -p 5443:443 registry-tester /bin/registry-test -test.v -test.run=TestRegistry
+
+test-performance: local-registry-image
+	docker run -it --rm -p 5443:443 registry-tester /bin/registry-test -test.v -test.run=TestMove
+	docker run -it --rm -p 5443:443 registry-tester /bin/registry-test -test.v -test.run=TestSaveNLoad
 
 test: deps lint test-units test-features
 

--- a/pkg/mover/registry_test.go
+++ b/pkg/mover/registry_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	TestChart = "/data/wordpress-chart"
-	Hints     = "/data/image-hints.yaml"
-	Target    = "*-wp-relocated.tgz"
+	TestChart = "/data/examples/simple-chart/mariadb-chart"
+	Hints     = "/data/examples/simple-chart/image-hints.yaml"
+	Target    = "*-testchart-relocated.tgz"
 	Prefix    = "relocated/local-example"
 
 	BadUser   = "notauser"

--- a/test/registry/Dockerfile
+++ b/test/registry/Dockerfile
@@ -22,7 +22,7 @@ ENV HOME /data
 COPY --from=compiled /go/bin/mkcert /bin/mkcert
 COPY --from=compiled /app/registry_test /bin/registry-test
 COPY --from=compiled /app/assets/docker-login.sh /bin/docker-login.sh
-COPY --from=compiled /app/examples/chart-with-subcharts/ /data/
+COPY --from=compiled /app/examples/ /data/examples
 COPY --from=registry /bin/registry /bin/registry
 COPY --from=registry /etc/docker/registry/config.yml /data/registry-config.yml
 COPY test/registry/local-registry.sh /bin/local-registry.sh


### PR DESCRIPTION
This PR changes to a lighter chart to be tested in the local-registry testing.

It also adds some optional or manually triggered tests to check what happens when the target registry is fresh, empty and how that affects to move vs save/load performance.

We might not want to merge this second part, but I think it is interesting to check as part of #104 discussions