### PR TITLE
Add test to protect a certain partner/customer use-case

### DIFF
--- a/pkg/mover/rewrite_rules.go
+++ b/pkg/mover/rewrite_rules.go
@@ -4,7 +4,8 @@
 package mover
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 )
@@ -21,16 +22,23 @@ type RewriteRules struct {
 
 func (r *RewriteRules) Validate() error {
 	if r.Registry != "" {
-		_, err := name.NewRegistry(r.Registry, name.StrictValidation)
-		if err != nil {
-			return errors.New("registry rule is not valid")
+		if strings.Contains(r.Registry, "/") {
+			_, err := name.NewRepository(r.Registry, name.StrictValidation)
+			if err != nil {
+				return fmt.Errorf("registry rule is not valid: %w", err)
+			}
+		} else {
+			_, err := name.NewRegistry(r.Registry, name.StrictValidation)
+			if err != nil {
+				return fmt.Errorf("registry rule is not valid: %w", err)
+			}
 		}
 	}
 
 	if r.RepositoryPrefix != "" {
 		_, err := name.NewRepository(r.RepositoryPrefix)
 		if err != nil {
-			return errors.New("repository prefix is not valid")
+			return fmt.Errorf("repository prefix rule is not valid: %w", err)
 		}
 	}
 

--- a/pkg/mover/rewrite_rules_test.go
+++ b/pkg/mover/rewrite_rules_test.go
@@ -28,6 +28,16 @@ var _ = Describe("RewriteRules", func() {
 		})
 	})
 
+	Context("compound registry rule", func() {
+		It("returns no error", func() {
+			rules := mover.RewriteRules{
+				Registry: "projects.vmware.com/myproject",
+			}
+			err := rules.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("valid repository prefix", func() {
 		It("returns no error", func() {
 			rules := mover.RewriteRules{
@@ -56,7 +66,7 @@ var _ = Describe("RewriteRules", func() {
 			}
 			err := rules.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("registry rule is not valid"))
+			Expect(err.Error()).To(Equal("registry rule is not valid: registries must be valid RFC 3986 URI authorities: a host with spaces"))
 		})
 	})
 
@@ -67,7 +77,7 @@ var _ = Describe("RewriteRules", func() {
 			}
 			err := rules.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("repository prefix is not valid"))
+			Expect(err.Error()).To(Equal("repository prefix rule is not valid: repository can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-./`: repositories/cannot/contain+plusses"))
 		})
 	})
 
@@ -79,7 +89,7 @@ var _ = Describe("RewriteRules", func() {
 			}
 			err := rules.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("registry rule is not valid"))
+			Expect(err.Error()).To(Equal("registry rule is not valid: registries must be valid RFC 3986 URI authorities: a.domain.with.an.invalid.port:lolwut"))
 		})
 	})
 })

--- a/test/features/chart_move_input_validation_feature_test.go
+++ b/test/features/chart_move_input_validation_feature_test.go
@@ -4,6 +4,8 @@
 package features_test
 
 import (
+	"regexp"
+
 	. "github.com/bunniesandbeatings/goerkin"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -105,11 +107,11 @@ var _ = Describe("relok8s chart move input validation", func() {
 		})
 
 		define.Then(`^it says that the registry is invalid$`, func() {
-			Expect(test.CommandSession.Err).To(Say("Error: registry rule is not valid"))
+			Expect(test.CommandSession.Err).To(Say(regexp.QuoteMeta("Error: registry rule is not valid: registries must be valid RFC 3986 URI authorities: what:is:this?")))
 		})
 
 		define.Then(`^it says that the repository prefix is invalid$`, func() {
-			Expect(test.CommandSession.Err).To(Say("Error: repository prefix is not valid"))
+			Expect(test.CommandSession.Err).To(Say(regexp.QuoteMeta("Error: repository prefix rule is not valid: repository can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-./`: 'What+is$this???'")))
 		})
 	})
 })

--- a/test/fixtures/complex-chart/.relok8s-images.yaml
+++ b/test/fixtures/complex-chart/.relok8s-images.yaml
@@ -1,0 +1,11 @@
+---
+- "{{.global.imageRegistry}}/{{ .subchart-1.deployment.imageName }}:{{ .subchart-1.deployment.dockerTag }}"
+- "{{.global.imageRegistry}}/{{ .subchart-2.deployment.imageName }}:{{ .subchart-2.deployment.dockerTag }}"
+- "{{.global.imageRegistry}}/{{ .subchart-3.deployment.imageName }}:{{ .subchart-3.deployment.dockerTag }}"
+- "{{.global.imageRegistry}}/{{ .subchart-4.deployment.imageName }}:{{ .subchart-4.deployment.dockerTag }}"
+- "{{.global.imageRegistry}}/{{ .subchart-5.deployment.imageName }}:{{ .subchart-5.deployment.dockerTag }}"
+- "{{.global.imageRegistry}}/{{ .subchart-6.deployment.imageName }}:{{ .subchart-6.deployment.dockerTag }}"
+- "{{.global.imageRegistry}}/{{ .subchart-7.deployment.imageName }}:{{ .subchart-7.deployment.dockerTag }}"
+- "{{.global.imageRegistry}}/{{ .subchart-8.deployment.imageName }}:{{ .subchart-8.deployment.dockerTag }}"
+- "{{.global.imageRegistry}}/{{ .subchart-9.deployment.imageName }}:{{ .subchart-9.deployment.dockerTag }}"
+- "{{.global.imageRegistry}}/{{ .subchart-10.deployment.imageName }}:{{ .subchart-10.deployment.dockerTag }}"

--- a/test/fixtures/complex-chart/Chart.yaml
+++ b/test/fixtures/complex-chart/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+dependencies:
+- name: subchart-1
+  repository: ""
+#- name: subchart-2
+#  repository: ""
+#- name: subchart-3
+#  repository: ""
+#- name: subchart-4
+#  repository: ""
+#- name: subchart-5
+#  repository: ""
+#- name: subchart-6
+#  repository: ""
+#- name: subchart-7
+#  repository: ""
+#- name: subchart-8
+#  repository: ""
+#- name: subchart-9
+#  repository: ""
+#- name: subchart-10
+#  repository: ""
+name: complex-chart
+type: application
+version: 1.0.0

--- a/test/fixtures/complex-chart/charts/subchart-1/Chart.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-1/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: subchart-1
+version: 1.0.0

--- a/test/fixtures/complex-chart/charts/subchart-1/values.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-1/values.yaml
@@ -1,0 +1,3 @@
+deployment:
+  imageName: "tiny"
+  dockerTag: "tiniest"

--- a/test/fixtures/complex-chart/charts/subchart-10/Chart.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-10/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: subchart-10
+version: 1.0.0

--- a/test/fixtures/complex-chart/charts/subchart-10/values.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-10/values.yaml
@@ -1,0 +1,3 @@
+deployment:
+  imageName: "tiny"
+  dockerTag: "tiniest"

--- a/test/fixtures/complex-chart/charts/subchart-2/Chart.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-2/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: subchart-2
+version: 1.0.0

--- a/test/fixtures/complex-chart/charts/subchart-2/values.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-2/values.yaml
@@ -1,0 +1,3 @@
+deployment:
+  imageName: "tiny"
+  dockerTag: "tiniest"

--- a/test/fixtures/complex-chart/charts/subchart-3/Chart.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-3/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: subchart-3
+version: 1.0.0

--- a/test/fixtures/complex-chart/charts/subchart-3/values.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-3/values.yaml
@@ -1,0 +1,3 @@
+deployment:
+  imageName: "tiny"
+  dockerTag: "tiniest"

--- a/test/fixtures/complex-chart/charts/subchart-4/Chart.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-4/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: subchart-4
+version: 1.0.0

--- a/test/fixtures/complex-chart/charts/subchart-4/values.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-4/values.yaml
@@ -1,0 +1,3 @@
+deployment:
+  imageName: "tiny"
+  dockerTag: "tiniest"

--- a/test/fixtures/complex-chart/charts/subchart-5/Chart.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-5/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: subchart-5
+version: 1.0.0

--- a/test/fixtures/complex-chart/charts/subchart-5/values.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-5/values.yaml
@@ -1,0 +1,3 @@
+deployment:
+  imageName: "tiny"
+  dockerTag: "tiniest"

--- a/test/fixtures/complex-chart/charts/subchart-6/Chart.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-6/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: subchart-6
+version: 1.0.0

--- a/test/fixtures/complex-chart/charts/subchart-6/values.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-6/values.yaml
@@ -1,0 +1,3 @@
+deployment:
+  imageName: "tiny"
+  dockerTag: "tiniest"

--- a/test/fixtures/complex-chart/charts/subchart-7/Chart.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-7/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: subchart-7
+version: 1.0.0

--- a/test/fixtures/complex-chart/charts/subchart-7/values.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-7/values.yaml
@@ -1,0 +1,3 @@
+deployment:
+  imageName: "tiny"
+  dockerTag: "tiniest"

--- a/test/fixtures/complex-chart/charts/subchart-8/Chart.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-8/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: subchart-8
+version: 1.0.0

--- a/test/fixtures/complex-chart/charts/subchart-8/values.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-8/values.yaml
@@ -1,0 +1,3 @@
+deployment:
+  imageName: "tiny"
+  dockerTag: "tiniest"

--- a/test/fixtures/complex-chart/charts/subchart-9/Chart.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-9/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: subchart-9
+version: 1.0.0

--- a/test/fixtures/complex-chart/charts/subchart-9/values.yaml
+++ b/test/fixtures/complex-chart/charts/subchart-9/values.yaml
@@ -1,0 +1,3 @@
+deployment:
+  imageName: "tiny"
+  dockerTag: "tiniest"

--- a/test/fixtures/complex-chart/values.yaml
+++ b/test/fixtures/complex-chart/values.yaml
@@ -1,0 +1,3 @@
+---
+global:
+  imageRegistry: harbor-repo.vmware.com/tanzu_isv_engineering


### PR DESCRIPTION
Adds a chart that uses global compound registry and repository and subcharts with image names.

Adjusts the registry rule validation to validate the full path if the registry rule was provided.

Signed-off-by: Pete Wall <pwall@vmware.com>