### PR TITLE
Fix loaded image manifests by canonizing them

### DIFF
--- a/inspect-image/main.go
+++ b/inspect-image/main.go
@@ -1,0 +1,121 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+)
+
+func mainE() error {
+	imageName := "harbor-repo.vmware.com/dockerhub-proxy-cache/library/busybox:1.33.1"
+	fmt.Println(imageName)
+	imgRef, err := name.NewTag(imageName)
+	if err != nil {
+		return err
+	}
+	image, err := remote.Image(imgRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return fmt.Errorf("failed to pull image %s: %w", imgRef.Name(), err)
+	}
+	digest, err := image.Digest()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Digest: %s\n", digest)
+	rawManifest, err := image.RawManifest()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Raw manifest:\n%s\n", string(rawManifest))
+	h := sha256.New()
+	h.Write(rawManifest)
+	recomputedDigest := h.Sum(nil)
+	hexRecomputedDigest := hex.EncodeToString(recomputedDigest)
+	fmt.Printf("Recomputed digest: %s\n", hexRecomputedDigest)
+	manifest, err := image.Manifest()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Manifest:\n%v\n", manifest)
+	rawJSONManifest, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Recomputed manifest RAW JSON:\n%s\n", string(rawJSONManifest))
+	buf := bytes.NewBufferString("")
+	if err := json.Indent(buf, rawJSONManifest, "", "   "); err != nil {
+		return err
+	}
+	jsonManifest := buf.Bytes()
+
+	fmt.Printf("Recomputed manifest pretty JSON:\n%s\n", string(jsonManifest))
+	h = sha256.New()
+	h.Write(jsonManifest)
+	reconstructedDigest := h.Sum(nil)
+	hexReconstructedDigest := hex.EncodeToString(reconstructedDigest)
+
+	fmt.Printf("Raw manifest hex dump:\n%s\n", hex.Dump(rawManifest))
+	fmt.Printf("Recomputed manifest pretty JSON hex dump:\n%s\n", hex.Dump(jsonManifest))
+
+	localImageFilename := "/tmp/busybox-1.33.1-test.tar"
+	imgRefs := map[name.Reference]v1.Image{}
+	imgRefs[imgRef] = image
+	if err := tarball.MultiRefWriteToFile(localImageFilename, imgRefs); err != nil {
+		return err
+	}
+	fmt.Printf("Saved image to %s\n", localImageFilename)
+
+	reloadedImg, err := tarball.ImageFromPath(localImageFilename, &imgRef)
+	if err != nil {
+		return err
+	}
+	reloadedDigest, err := reloadedImg.Digest()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Reloaded Digest: %s\n", reloadedDigest.Hex)
+	rawReloadedManifest, err := reloadedImg.RawManifest()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Raw Reloaded manifest:\n%s\n", string(rawReloadedManifest))
+
+	buf.Reset()
+	if err := json.Indent(buf, rawReloadedManifest, "", "   "); err != nil {
+		return err
+	}
+	rebuiltManifest := buf.Bytes()
+	fmt.Printf("Rebuilt Reloaded manifest:\n%s\n", string(rebuiltManifest))
+
+	h = sha256.New()
+	h.Write(rebuiltManifest)
+	rebuiltDigest := h.Sum(nil)
+	hexRebuiltDigest := hex.EncodeToString(rebuiltDigest)
+	fmt.Printf("Rebuilt digest: %s\n", string(hexRebuiltDigest))
+
+	fmt.Printf("Digest:               %s\n", digest.Hex)
+	fmt.Printf("Recomputed digest:    %s\n", hexRecomputedDigest)
+	fmt.Printf("Reconstructed digest: %s\n", hexReconstructedDigest)
+
+	fmt.Printf("Reloaded Digest:      %s\n", reloadedDigest.Hex)
+	fmt.Printf("Rebuilt digest:       %s\n", string(hexRebuiltDigest))
+	return nil
+}
+
+func main() {
+	if err := mainE(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/fixed_manifest_image.go
+++ b/internal/fixed_manifest_image.go
@@ -1,0 +1,100 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package internal
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+type fixedManifestImage struct {
+	v1.Image
+}
+
+// FixedManifestImage returns a image that produces a manifest that conforms to
+// the canonical form found in registries:
+// - JSON pretty print of the manifest with 3 spaces indentation.
+//
+// Sample:
+// {
+// 	"schemaVersion": 2,
+// 	"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+// 	"config": {
+// 		 "mediaType": "application/vnd.docker.container.image.v1+json",
+// 		 "size": 1456,
+// 		 "digest": "sha256:16ea53ea7c652456803632d67517b78a4f9075a10bfdc4fc6b7b4cbf2bc98497"
+// 	},
+// 	"layers": [
+// 		 {
+// 				"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+// 				"size": 767322,
+// 				"digest": "sha256:24fb2886d6f6c5d16481dd7608b47e78a8e92a13d6e64d87d57cb16d5f766d63"
+// 		 }
+// 	]
+// }
+func FixedManifestImage(img v1.Image) v1.Image {
+	return &fixedManifestImage{Image: img}
+}
+
+// RawManifest implements v1.Image's RawManifest wrapping the raw manifest
+// in a repo canonized way
+// See v1.Image interface:
+// https://github.com/google/go-containerregistry/blob/main/pkg/v1/image.go
+func (img *fixedManifestImage) RawManifest() ([]byte, error) {
+	raw, err := img.Image.RawManifest()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve underlying image raw manifest: %w", err)
+	}
+	canonized, err := canonizeManifest(raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to canonize raw manifest: %w", err)
+	}
+	return canonized, nil
+}
+
+// Digest implements v1.Image's Digest ensuring the canonized raw manigest is
+// the one being digested
+// See v1.Image interface:
+// https://github.com/google/go-containerregistry/blob/main/pkg/v1/image.go
+func (img *fixedManifestImage) Digest() (v1.Hash, error) {
+	originalDigest, err := img.Image.Digest()
+	if err != nil {
+		return v1.Hash{}, fmt.Errorf("failed to retrieve underlying image digest: %w", err)
+	}
+	h, err := hasherFor(originalDigest.Algorithm)
+	if err != nil {
+		return v1.Hash{}, fmt.Errorf("failed to prepare digester: %w", err)
+	}
+	var digest v1.Hash
+	digest.Algorithm = originalDigest.Algorithm
+	manifest, err := img.RawManifest()
+	if err != nil {
+		return v1.Hash{}, fmt.Errorf("failed to read raw manifest: %w", err)
+	}
+	h.Write(manifest)
+	digest.Hex = hex.EncodeToString(h.Sum(nil))
+	return digest, nil
+}
+
+func canonizeManifest(rawManifest []byte) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	if err := json.Indent(buf, rawManifest, "", "   "); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func hasherFor(alg string) (hash.Hash, error) {
+	if strings.ToLower(alg) == "sha256" {
+		return sha256.New(), nil
+	}
+	return nil, fmt.Errorf("Digest algorithm %s not supported", alg)
+}

--- a/pkg/mover/intermediate.go
+++ b/pkg/mover/intermediate.go
@@ -207,10 +207,11 @@ func (ib *intermediateBundle) loadImage(imageRef name.Reference) (v1.Image, stri
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to make tag from %s: %w", imageRef.Name(), err)
 	}
-	image, err := tarball.Image(newTarInTarOpener(ib.bundlePath, imagesTar), &tag)
+	loadedImage, err := tarball.Image(newTarInTarOpener(ib.bundlePath, imagesTar), &tag)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to export image %s from tarball %s: %w", tag.Name(), ib.bundlePath, err)
 	}
+	image := internal.FixedManifestImage(loadedImage)
 	digest, err := image.Digest()
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to get image digest for %s: %w", tag.Name(), err)


### PR DESCRIPTION
Signed-off-by: Jose Luis Vazquez Gonzalez <josvaz@vmware.com>

This is a draft fix which seems to be working.

It does the following:

1.  **Intercept the loaded image manifest to reformat its JSON to be pretty printed with 3 spaces indent**.

  - That seems to be the format used by registries, or at least the registries we are using.
  - The loaded image had the same JSON contents, but unformatted, without any indents or end of lines. If you ask me, that makes more sense, but we want to keep the original digest the indent 3 spaces format and standard pretty print new lines is the way to go.

2.  **Intercept also the digest call to ensure the reformatted manifest is being used**.

I did a couple of tests and this seems to work. Which means, the target repo takes whatever format of the manifest JSON we pass in at push, apparently.

Which begs the question, **did the registry use that weird 3 spaces pretty print format or was it just given it that way?**

That leads to the fact **while this works with our current example, it might not be correct**. We cannot be sure all registries use that weird pretty printed indenting with 3 spaces JSON, any variation will break the expected digest. Still, **be aware the correct solution is more involved and ugly**:
- We would need to change the bundle format to actually store the original manifests.
- And instead fo fix them on the fly at load time, use the pre-recorded manifests instead of the ones computed from the bundle itself.