### PR TITLE
fix(intermediate): Stable content digest from intermediate bundle

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,7 +5,10 @@ on:
     branches:
       - main
   pull_request:
-
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
 jobs:
   golangci:
     name: lint
@@ -15,4 +18,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42
+          version: v1.43
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,4 +15,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.43
+          version: v1.42

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           version: v1.43
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          only-new-issues: true
+          # only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           version: v1.43
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,4 +15,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42
+          version: v1.43

--- a/internal/canonical_docker_image.go
+++ b/internal/canonical_docker_image.go
@@ -1,0 +1,39 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package internal
+
+import (
+	"encoding/json"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+)
+
+// CanonicalDockerImage is an image which imageManifest has been modified (indented)
+// to follow the same format used by docker during push [1] and hence
+// preserve the digest once crafted and pushed from a tarball
+// [1] https://github.com/docker/cli/blob/a32cd16160f1b41c1c4ae7bee4dac929d1484e59/cli/command/manifest/push.go#L230
+// It reimplements v1.Image https://github.com/google/go-containerregistry/blob/main/pkg/v1/image.go#L22
+type CanonicalDockerImage struct {
+	v1.Image
+}
+
+// NewCanonicalDockerImage returns an instance of the the image which imagemanifest comes indented
+func NewCanonicalDockerImage(image v1.Image) *CanonicalDockerImage {
+	return &CanonicalDockerImage{Image: image}
+}
+
+func (img *CanonicalDockerImage) RawManifest() ([]byte, error) {
+	originalManifest, err := img.Image.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	// Indent the raw manifest similarly to what Docker push does [1]
+	return json.MarshalIndent(originalManifest, "", "   ")
+}
+
+func (img *CanonicalDockerImage) Digest() (v1.Hash, error) {
+	return partial.Digest(img)
+}

--- a/internal/canonical_docker_image.go
+++ b/internal/canonical_docker_image.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package internal

--- a/internal/canonical_docker_image.go
+++ b/internal/canonical_docker_image.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package internal


### PR DESCRIPTION
Based on the experience an implementation hints showed here https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/121, thanks @josvazg 

As you can see in [this example code](https://gist.github.com/migmartri/0eb70f4e12c8782a526f52413c5266cf) the issue appears in the use-case where an image is dumped into a tarball first and then extracted+pushed. This is because the image manifest does not get stored in the tarball and gocontainerregistry crafts [[1]](https://github.com/google/go-containerregistry/blob/main/pkg/v1/tarball/image.go#L319) and marshalls [[2]](https://github.com/google/go-containerregistry/blob/7adcadef6bc8adf07cc587a5a5a443afe7603d54/pkg/v1/partial/with.go#L164) a new one before pushing it to the destination registry. 

This should be ok except that `docker push` itself crafts the manifest slightly different [[3]](https://github.com/docker/cli/blob/a32cd16160f1b41c1c4ae7bee4dac929d1484e59/cli/command/manifest/push.go#L223), it adds indentation to the file so there is a mismatch between original source images (usually pushed using the Docker CLI) and the new ones (computed by gocontainerregistry as described above)  https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/issues/120

This patch solves the issue by

- Providing a new struct type that re-implements the ManifestRaw and Digest methods to follow the 3 spaces indentation using by Docker
- Updating the intermediate bundle load method to cast the extracted images into this new canonical struct type.

NOTE: This is not a general purpose solution, it only makes sense when you want to **airgap move images that originally were pushed using the Docker CLI**, if these images were pushed using other methods/tools the mistmatch will happen. A better solution would be to store the original manifest in the intermediate bundle itself but that will require more work and its impact in practice is not clear yet, so this can be a good first step in that direction. We'll revisit it in the future.

EXAMPLE

before
```bash
go run main.go chart move /tmp/test/mariadb-intermediate.tar --registry us-west1-docker.pkg.dev --repo-prefix bitnamigcetest2/relok8s-test
Intermediate bundle provided
Computing relocation...

Error: failed to compute chart rewrites: failed check, use forcePush option to override :image us-west1-docker.pkg.dev/bitnamigcetest2/relok8s-test/mariadb:10.5.13-centos-7-r33 already exists with a different digest (local: sha256:ef51c23c6929832f9b25ae31d469f2cfbe36575110b5d574bacfb82b9d710e3d remote: sha256:60dd2f5d4b04e90e968eb32acdb737ab522b532a97ccbc473663b219d1d1bec1). Will not overwrite
```

after the fix
```bash
go run main.go chart move mariadb-intermediate.tar --registry us-west1-docker.pkg.dev --repo-prefix bitnamigcetest2/relok8s-test 
Intermediate bundle provided
Computing relocation...

Image copies:
 (bundle mariadb-intermediate.tar:gcr.io/sys-2b0109it/demo/bitnami/mariadb:10.5.13-centos-7-r33) => us-west1-docker.pkg.dev/bitnamigcetest2/relok8s-test/mariadb:10.5.13-centos-7-r33 (sha256:60dd2f5d4b04e90e968eb32acdb737ab522b532a97ccbc473663b219d1d1bec1) (already exists)
 (bundle mariadb-intermediate.tar:gcr.io/sys-2b0109it/demo/bitnami/mysqld-exporter:0.13.0-centos-7-r196) => us-west1-docker.pkg.dev/bitnamigcetest2/relok8s-test/mysqld-exporter:0.13.0-centos-7-r196 (sha256:58001f9ed8f1ec06b9ec162e60e403a68a3d0e613c41904adf804e077501f48a) (already exists)
 (bundle mariadb-intermediate.tar:gcr.io/sys-2b0109it/demo/bitnami/tac-shell:7) => us-west1-docker.pkg.dev/bitnamigcetest2/relok8s-test/tac-shell:7 (sha256:d2f6dca5edc575ac96c4a6692608d6d89db92e01505d11283319a322e769e753) (already exists)
```

Fixes https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/issues/120