### PR TITLE
Update headers - it's 2022 now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 VMware, Inc.
+# Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 FROM golang:1.17 as builder
 ARG VERSION

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
  Asset Relocation Tool for Kubernetes
-Copyright 2021 VMware, Inc.
+Copyright 2022 VMware, Inc.
 
 The BSD-2 license (the "License") set forth below applies to all parts of the Asset Relocation Tool for Kubernetes project. You may not use this file except in compliance with the License.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 VMware, Inc.
+# Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 
 SHELL = /bin/bash

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Asset Relocation Tool for Kubernetes
-Copyright 2021 VMware, Inc.
+Copyright 2022 VMware, Inc.
 
 This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.  
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Relok8s
-Copyright 2021 VMware, Inc.
+Copyright 2022 VMware, Inc.
 
 This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.  
 

--- a/assets/docker-login.sh
+++ b/assets/docker-login.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2021 VMware, Inc.
+# Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 
 set -euo pipefail

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 VMware, Inc.
+# Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/photon:3.0-20210716
 

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 VMware, Inc.
+# Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 resource_types:

--- a/ci/tasks/build.yaml
+++ b/ci/tasks/build.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 VMware, Inc.
+# Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 platform: linux

--- a/ci/tasks/test.yaml
+++ b/ci/tasks/test.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 VMware, Inc.
+# Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 platform: linux

--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package cmd

--- a/cmd/chart_test.go
+++ b/cmd/chart_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package cmd

--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package cmd_test

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package cmd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package cmd

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package cmd

--- a/examples/concourse-pipeline/pipeline.yaml
+++ b/examples/concourse-pipeline/pipeline.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 VMware, Inc.
+# Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 resource_types:

--- a/internal/container_registry.go
+++ b/internal/container_registry.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package internal

--- a/internal/image_change.go
+++ b/internal/image_change.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package internal

--- a/internal/image_template.go
+++ b/internal/image_template.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package internal

--- a/internal/image_template_test.go
+++ b/internal/image_template_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package internal_test

--- a/internal/internal_suite_test.go
+++ b/internal/internal_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package internal_test

--- a/internal/layer_cache.go
+++ b/internal/layer_cache.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package internal

--- a/internal/rewrite_action.go
+++ b/internal/rewrite_action.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package internal

--- a/internal/yamlops/helpers_test.go
+++ b/internal/yamlops/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package yamlops_test

--- a/internal/yamlops/nodesearch.go
+++ b/internal/yamlops/nodesearch.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package yamlops

--- a/internal/yamlops/nodesearch_test.go
+++ b/internal/yamlops/nodesearch_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package yamlops_test

--- a/internal/yamlops/scanner.go
+++ b/internal/yamlops/scanner.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package yamlops

--- a/internal/yamlops/scanner_test.go
+++ b/internal/yamlops/scanner_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package yamlops_test

--- a/internal/yamlops/yamlops.go
+++ b/internal/yamlops/yamlops.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package yamlops

--- a/internal/yamlops/yamlops_test.go
+++ b/internal/yamlops/yamlops_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package yamlops_test

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package main

--- a/pkg/mover/auth.go
+++ b/pkg/mover/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package mover

--- a/pkg/mover/chart.go
+++ b/pkg/mover/chart.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package mover

--- a/pkg/mover/chart_test.go
+++ b/pkg/mover/chart_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package mover

--- a/pkg/mover/doc_test.go
+++ b/pkg/mover/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package mover

--- a/pkg/mover/mover_suite_test.go
+++ b/pkg/mover/mover_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package mover_test

--- a/pkg/mover/registry_test.go
+++ b/pkg/mover/registry_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package mover_test

--- a/pkg/mover/rewrite_rules.go
+++ b/pkg/mover/rewrite_rules.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package mover

--- a/pkg/mover/rewrite_rules_test.go
+++ b/pkg/mover/rewrite_rules_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package mover_test

--- a/pkg/mover/tar.go
+++ b/pkg/mover/tar.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package mover

--- a/pkg/mover/tar_test.go
+++ b/pkg/mover/tar_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package mover

--- a/test/common_steps.go
+++ b/test/common_steps.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package test

--- a/test/external/external_suite_test.go
+++ b/test/external/external_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package external_test

--- a/test/external/external_test.go
+++ b/test/external/external_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package external_test

--- a/test/features/chart_move_feature_test.go
+++ b/test/features/chart_move_feature_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package features_test

--- a/test/features/chart_move_input_validation_feature_test.go
+++ b/test/features/chart_move_input_validation_feature_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package features_test

--- a/test/features/features_suite_test.go
+++ b/test/features/features_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package features_test

--- a/test/features/version_test.go
+++ b/test/features/version_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package features_test

--- a/test/fixtures/Makefile
+++ b/test/fixtures/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 VMware, Inc.
+# Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 
 .PHONY: build clean rebuild

--- a/test/registry/Dockerfile
+++ b/test/registry/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 VMware, Inc.
+# Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 FROM golang:1.17 as compiled
 RUN cd /go && \

--- a/test/test_helpers.go
+++ b/test/test_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package test


### PR DESCRIPTION
And the linter complaints if the headers are so last year...

Signed-off-by: Jose Luis Vazquez Gonzalez <josvaz@vmware.com>