### PR TITLE
fix(linter): Allow multiple copyright years

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,3 +27,6 @@ linters-settings:
     threshold: 400
   goheader:
     template-path: code-header-template.txt
+    values:
+      regexp:
+        copyright-year: 202[1-2]

--- a/code-header-template.txt
+++ b/code-header-template.txt
@@ -1,2 +1,2 @@
-Copyright {{YEAR}} VMware, Inc.
+Copyright {{copyright-year}} VMware, Inc.
 SPDX-License-Identifier: BSD-2-Clause


### PR DESCRIPTION
Updates our linter configuration to accept copyright headers that span from 2021 to 2022. This will allow us to preserve the existing headers while allowing us to add up to date ones for new files.

I've read in [multiple](https://stackoverflow.com/a/2391555) [places](https://opensource.google/docs/copyright/#the-year) that ideally the original date should be retained, 

Signed-off-by: Miguel Martinez Trivino <mtrivino@vmware.com>