### PR TITLE
fix: rename goreleaser action

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,6 +1,6 @@
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
-name: release
+name: Release
 
 on:
   push:


### PR DESCRIPTION
It seems that our new release action does not work, it's like github is stuck with a previous version of another workflow called `release` that was added some time ago as POC in a branch.

![image](https://user-images.githubusercontent.com/24523/148944851-1aa99312-27b3-442d-ba62-1d15d3871561.png)


In order to unlock this I've performed two changes, to change the name of the workflow file and it's actual identifier.