### PR TITLE
feat: Release container images into Github Packages repository

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -16,6 +16,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Unshallow
         run: git fetch --prune --unshallow
+      - name: Docker login to Github Packages
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v1
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,7 @@ dockers:
       - "VERSION={{ .Version }}"
     extra_files:
       - assets/docker-login.sh
+      - relok8s
 archives:
   - replacements:
       386: i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,6 @@ dockers:
       - "VERSION={{ .Version }}"
     extra_files:
       - assets/docker-login.sh
-      - relok8s
 archives:
   - replacements:
       386: i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,8 +9,6 @@ builds:
     binary: relok8s
 dockers:
   -
-    ids:
-      - release
     dockerfile: Dockerfile
     image_templates:
       - "ghcr.io/vmware-tanzu/asset-relocation-tool-for-kubernetes:{{ .Tag }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,17 @@ builds:
     ldflags:
       - -X github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/cmd.Version={{ .Version }}
     binary: relok8s
+dockers:
+  -
+    ids:
+      - release
+    dockerfile: Dockerfile
+    image_templates:
+      - "ghcr.io/vmware-tanzu/asset-relocation-tool-for-kubernetes:{{ .Tag }}"
+      - "ghcr.io/vmware-tanzu/asset-relocation-tool-for-kubernetes:latest"
+    build_flag_templates:
+      - "--build-arg"
+      - "VERSION={{ .Version }}"
 archives:
   - replacements:
       386: i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,8 @@ dockers:
     build_flag_templates:
       - "--build-arg"
       - "VERSION={{ .Version }}"
+    extra_files:
+      - assets/docker-login.sh
 archives:
   - replacements:
       386: i386

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN make test && make build
 FROM photon:4.0
 LABEL description="Asset Relocation Tool for Kubernetes"
 LABEL maintainer="tanzu-isv-engineering@groups.vmware.com"
+LABEL org.opencontainers.image.source https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ LABEL maintainer="tanzu-isv-engineering@groups.vmware.com"
 LABEL org.opencontainers.image.source https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes
 
 COPY assets/docker-login.sh /usr/local/bin/docker-login.sh
-COPY relok8s /usr/local/bin
+COPY ./relok8s /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/relok8s"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,17 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
-FROM golang:1.17 as builder
-ARG VERSION
 
-COPY . /asset-relocation-tool-for-kubernetes/
-ENV GOPATH=
-ENV PATH="${PATH}:/root/go/bin"
-WORKDIR /asset-relocation-tool-for-kubernetes/
-RUN make test && make build
-
+# Distributes the relok8s binary previously crafted by the release process
+# as part of the CI release action
 FROM photon:4.0
+ARG VERSION
+ENV VERSION=${VERSION}
+
 LABEL description="Asset Relocation Tool for Kubernetes"
 LABEL maintainer="tanzu-isv-engineering@groups.vmware.com"
 LABEL org.opencontainers.image.source https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes
 
-WORKDIR /
-
-RUN yum -y install diffutils jq
-
 COPY assets/docker-login.sh /usr/local/bin/docker-login.sh
-COPY --from=builder /asset-relocation-tool-for-kubernetes/build/relok8s /usr/local/bin/relok8s
+COPY ./relok8s /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/relok8s"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ LABEL maintainer="tanzu-isv-engineering@groups.vmware.com"
 LABEL org.opencontainers.image.source https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes
 
 COPY assets/docker-login.sh /usr/local/bin/docker-login.sh
-COPY ./relok8s /usr/local/bin
+COPY relok8s /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/relok8s"]
 


### PR DESCRIPTION
Update goreleaser to also build container images with latest versions of the binary inside pushed to Github packages repository `ghcr.io/vmware-tanzu/asset-relocation-tool-for-kubernetes`

The Dockerfile has also been updated to leverage the binary created by goreleaser itself

Tested it and an image was built and pushed as expected https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pkgs/container/asset-relocation-tool-for-kubernetes/13030106?tag=v0.3.61-pre https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/actions/runs/1683473654


Refs https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/issues/127