### PR TITLE
fix: add missing deps in upstream Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ LABEL description="Asset Relocation Tool for Kubernetes"
 LABEL maintainer="tanzu-isv-engineering@groups.vmware.com"
 LABEL org.opencontainers.image.source https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes
 
+# Deps required for docker-login and the additional testing performed in the CI using this image
+# TODO: remove these dependencies
+RUN yum -y install diffutils jq
+
 COPY assets/docker-login.sh /usr/local/bin/docker-login.sh
 COPY ./relok8s /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/relok8s"]


### PR DESCRIPTION
During the implementation of https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/128 a regression was added which dropped some required deps.

This patch puts them back.

Signed-off-by: Miguel Martinez Trivino <mtrivino@vmware.com>