### PR TITLE
chore: remove linter from concourse

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -8,9 +8,6 @@ WORKDIR /
 RUN yum -y install build-essential coreutils gawk gcc git go-1.17.2-1.ph3.x86_64 jq make
 ENV PATH="/root/go/bin:${PATH}"
 
-ARG GOLANGCI_LINT_VERSION="v1.42.0"
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
-
 # Install go packages used for building and testing
 RUN go get -u github.com/maxbrunsfeld/counterfeiter/v6 \
     github.com/onsi/ginkgo/ginkgo \

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -201,11 +201,6 @@ jobs:
               context: merge-conflict
               status: failure
       - do:
-        - task: run-lint
-          image: test-image
-          file: source/ci/tasks/test.yaml
-          params:
-            MAKE_TARGET: lint
         - task: run-unit-tests
           image: test-image
           file: source/ci/tasks/test.yaml

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -99,11 +99,6 @@ jobs:
             trigger: true
           - get: source
             trigger: true
-      - task: run-lint
-        image: test-image
-        file: source/ci/tasks/test.yaml
-        params:
-          MAKE_TARGET: lint
       - task: run-unit-tests
         image: test-image
         file: source/ci/tasks/test.yaml


### PR DESCRIPTION
We are currently running the golangci-lint twice, once in the github action and also in the concourse pipeline. 

In my opinion the execution in the internal pipeline should be remove because of

- We are moving away from the use of a monolithic internal pipeline step in favor of public facing single purpose Github actions
- By running it in two places, by two different systems we can run into inconsistencies, for example, the golangci github action is configured in a specific way that concourse doesn't know about.   

Signed-off-by: Miguel Martinez Trivino <mtrivino@vmware.com>