### PR TITLE
feat: container keychains exclusion

### DIFF
--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -112,12 +112,16 @@ func moveChart(cmd *cobra.Command, args []string) error {
 		Source: mover.Source{
 			Chart:          mover.ChartSpec{},
 			ImageHintsFile: imagePatternsFile,
+			// Use local keychain for authentication
+			Containers: mover.Containers{UseDefaultLocalKeychain: true},
 		},
 		Target: mover.Target{
-			Chart: mover.ChartSpec{},
-			Rules: *targetRewriteRules,
+			Chart:      mover.ChartSpec{},
+			Rules:      *targetRewriteRules,
+			Containers: mover.Containers{UseDefaultLocalKeychain: true},
 		},
 	}
+
 	inputChartPath := args[0]
 	if mover.IsIntermediateBundle(inputChartPath) {
 		cmd.Println("Intermediate bundle provided")

--- a/pkg/mover/auth.go
+++ b/pkg/mover/auth.go
@@ -10,13 +10,14 @@ import "github.com/google/go-containerregistry/pkg/authn"
 // See https://pkg.go.dev/github.com/google/go-containerregistry/pkg/authn#Keychain
 //
 // Returns a custom credentials authn.Authenticator if the given resource
-// RegistryStr() matches the Repository, otherwise it falls back to the default
-// KeyChain which may include local docker credentials.
+// RegistryStr() matches the Repository, otherwise it returns annonymous access
 func (repo ContainerRepository) Resolve(resource authn.Resource) (authn.Authenticator, error) {
 	if repo.Server == resource.RegistryStr() {
 		return repo, nil
 	}
-	return authn.DefaultKeychain.Resolve(resource)
+
+	// if no credentials are provided we return annon authentication
+	return authn.Anonymous, nil
 }
 
 // Authorization implements an authn.Authenticator
@@ -26,4 +27,14 @@ func (repo ContainerRepository) Resolve(resource authn.Resource) (authn.Authenti
 // Returns an authn.AuthConfig with a user / password pair to be used for authentication
 func (repo ContainerRepository) Authorization() (*authn.AuthConfig, error) {
 	return &authn.AuthConfig{Username: repo.Username, Password: repo.Password}, nil
+}
+
+// Define a container images keychain based on the settings provided via the containers struct
+// If useDefaultKeychain is set, use config/docker.json otherwise load the provided creds (if any)
+func getContainersKeychain(c Containers) authn.Keychain {
+	if c.UseDefaultLocalKeychain {
+		return authn.DefaultKeychain
+	}
+
+	return c.ContainerRepository
 }


### PR DESCRIPTION
This patch changes the current containers authentication mechanism so instead of falling back to the default keychain, its use must be explicitly set.

The reason for this change is because while using relok8s as a library from charts-syncer I noticed that the fallback didn't make sense in that tool and there was not an easy way to disable it without providing bogus credentials, which also broke anonymous access to public registries.

From the POV of relok8s, nothing has changed, the CLI itself indicates that it wants to use the local keychain