### PR TITLE
feat: validate credentials

### DIFF
--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -113,12 +113,12 @@ func moveChart(cmd *cobra.Command, args []string) error {
 			Chart:          mover.ChartSpec{},
 			ImageHintsFile: imagePatternsFile,
 			// Use local keychain for authentication
-			Containers: mover.Containers{UseDefaultLocalKeychain: true},
+			ContainersAuth: &mover.ContainersAuth{UseDefaultLocalKeychain: true},
 		},
 		Target: mover.Target{
-			Chart:      mover.ChartSpec{},
-			Rules:      *targetRewriteRules,
-			Containers: mover.Containers{UseDefaultLocalKeychain: true},
+			Chart:          mover.ChartSpec{},
+			Rules:          *targetRewriteRules,
+			ContainersAuth: &mover.ContainersAuth{UseDefaultLocalKeychain: true},
 		},
 	}
 

--- a/pkg/mover/auth.go
+++ b/pkg/mover/auth.go
@@ -3,7 +3,13 @@
 
 package mover
 
-import "github.com/google/go-containerregistry/pkg/authn"
+import (
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+)
 
 // Resolve implements an authn.KeyChain
 //
@@ -11,7 +17,7 @@ import "github.com/google/go-containerregistry/pkg/authn"
 //
 // Returns a custom credentials authn.Authenticator if the given resource
 // RegistryStr() matches the Repository, otherwise it returns annonymous access
-func (repo ContainerRepository) Resolve(resource authn.Resource) (authn.Authenticator, error) {
+func (repo *OCICredentials) Resolve(resource authn.Resource) (authn.Authenticator, error) {
 	if repo.Server == resource.RegistryStr() {
 		return repo, nil
 	}
@@ -25,16 +31,41 @@ func (repo ContainerRepository) Resolve(resource authn.Resource) (authn.Authenti
 // See https://pkg.go.dev/github.com/google/go-containerregistry/pkg/authn#Authenticator
 //
 // Returns an authn.AuthConfig with a user / password pair to be used for authentication
-func (repo ContainerRepository) Authorization() (*authn.AuthConfig, error) {
+func (repo *OCICredentials) Authorization() (*authn.AuthConfig, error) {
 	return &authn.AuthConfig{Username: repo.Username, Password: repo.Password}, nil
 }
 
-// Define a container images keychain based on the settings provided via the containers struct
-// If useDefaultKeychain is set, use config/docker.json otherwise load the provided creds (if any)
-func getContainersKeychain(c Containers) authn.Keychain {
-	if c.UseDefaultLocalKeychain {
-		return authn.DefaultKeychain
+// Define a container registry keychain based on the settings provided in containers Auth
+// If useDefaultKeychain is set, use config/docker.json otherwise it will load the provided credentials (if any)
+func getContainersKeychain(c *ContainersAuth) (authn.Keychain, error) {
+	// No credentials provided
+	if !c.UseDefaultLocalKeychain && c.Credentials == nil {
+		return nil, errors.New("either local keychain or explicit credentials are required")
 	}
 
-	return c.ContainerRepository
+	if c.UseDefaultLocalKeychain && c.Credentials != nil {
+		return nil, errors.New("you can use either local keychain or explicit credentials not both")
+	}
+
+	if c.UseDefaultLocalKeychain {
+		return authn.DefaultKeychain, nil
+	}
+
+	return validateOCICredentials(c.Credentials)
+}
+
+// validate if the provided OCI credentials are valid
+// They include a username, password and a valid (RFC 3986 URI authority) serverName
+func validateOCICredentials(c *OCICredentials) (authn.Keychain, error) {
+	if c.Username == "" || c.Password == "" || c.Server == "" {
+		return nil, errors.New("OCI credentials require an username, password and a server name")
+	}
+
+	// See https://github.com/google/go-containerregistry/blob/main/pkg/name/registry.go#L97
+	// Valid RFC 3986 URI authority
+	if uri, err := url.Parse("//" + c.Server); err != nil || uri.Host != c.Server {
+		return nil, fmt.Errorf("credentials server name %q must not contain a scheme (\"http://\") nor a path. Example of valid registry names are \"myregistry.io\" or \"myregistry.io:9999\"", c.Server)
+	}
+
+	return c, nil
 }

--- a/pkg/mover/auth_test.go
+++ b/pkg/mover/auth_test.go
@@ -1,0 +1,84 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package mover
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+func TestGetContainersKeychain(t *testing.T) {
+	explicitCreds := &OCICredentials{Username: "user", Password: "pass", Server: "server.io"}
+
+	tests := []struct {
+		name      string
+		auth      *ContainersAuth
+		want      authn.Keychain
+		wantError bool // if the function should return an error
+	}{
+		// Valid triplets
+		{name: "neither local nor provided credentials", auth: &ContainersAuth{}, wantError: true},
+		{name: "both local and provided credentials",
+			auth: &ContainersAuth{
+				UseDefaultLocalKeychain: true,
+				Credentials:             explicitCreds},
+			wantError: true},
+		{name: "localKeychain", auth: &ContainersAuth{UseDefaultLocalKeychain: true}, want: authn.DefaultKeychain},
+		{
+			name: "valid explicit creds",
+			auth: &ContainersAuth{
+				Credentials: explicitCreds,
+			},
+			want: explicitCreds,
+		},
+		{name: "invalid provided credentials",
+			auth: &ContainersAuth{
+				Credentials: &OCICredentials{Username: "user", Password: "pass", Server: "https://server.io"}},
+			wantError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotError := getContainersKeychain(test.auth)
+			if gotError == nil == test.wantError {
+				t.Errorf("expected error %t, got error %q. auth=%v", test.wantError, gotError, test.auth)
+			}
+
+			if got != test.want {
+				t.Errorf("got=%v, want=%v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateOCICredentials(t *testing.T) {
+	var tests = []struct {
+		username  string
+		password  string
+		server    string
+		wantError bool // if the function should return an error
+	}{
+		// Valid triplets
+		{"username", "password", "server.io", false},
+		{"username", "password", "server.io:9999", false},
+
+		// Missing one of the three items
+		{"", "password", "server.io", true},
+		{"username", "", "server.io", true},
+		{"username", "password", "", true},
+
+		// Invalid serverName
+		{"username", "password", "http://server.io", true},
+		{"username", "password", "//server.io", true},
+		{"username", "password", "server.io/baz", true},
+	}
+
+	for _, test := range tests {
+		_, gotError := validateOCICredentials(&OCICredentials{test.server, test.username, test.password})
+		if gotError == nil == test.wantError {
+			t.Errorf("expected error %t, got error %q. username=%q, pass=%q, server=%q", test.wantError, gotError, test.username, test.password, test.server)
+		}
+	}
+}


### PR DESCRIPTION
Validates the correctness of the provided OCI credentials. Additionally it updates the embed structs to be pointer to struts for consistency and simplification on the side of the caller (the caller does not always need to provide an empty struct)

FIxes https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/issues/143