### PR TITLE
Pin test-image to 20.04

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
-FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/ubuntu
+FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/ubuntu:20.04
 
 WORKDIR /
 


### PR DESCRIPTION
Signed-off-by: Pete Wall <pwall@vmware.com>

This fixes a strange apt issue seen only in CI when using the non-pinned version.