### PR TITLE
Bump docker from 23.0.1+incompatible to 23.0.3+incompatible

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.52.2
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes
 
-go 1.18
+go 1.20
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible
@@ -19,7 +19,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
-	github.com/docker/cli v23.0.1+incompatible // indirect
+	github.com/docker/cli v23.0.3+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v23.0.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/divideandconquer/go-merge v0.0.0-20160829212531-bc6b3a394b4e h1:s/uRx+1SCHqxOKsQiREmWZDxZVhdsiYgPNa8CS+J+o4=
 github.com/divideandconquer/go-merge v0.0.0-20160829212531-bc6b3a394b4e/go.mod h1:Y+Et20MYTm/6Do72xZ3niVupcTZXTnsj0Y663IpuUkA=
-github.com/docker/cli v23.0.1+incompatible h1:LRyWITpGzl2C9e9uGxzisptnxAn1zfZKXy13Ul2Q5oM=
-github.com/docker/cli v23.0.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v23.0.3+incompatible h1:Zcse1DuDqBdgI7OQDV8Go7b83xLgfhW1eza4HfEdxpY=
+github.com/docker/cli v23.0.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v23.0.1+incompatible h1:vjgvJZxprTTE1A37nm+CLNAdwu6xZekyoiVlUZEINcY=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -17,7 +17,7 @@ github.com/cyphar/filepath-securejoin
 # github.com/divideandconquer/go-merge v0.0.0-20160829212531-bc6b3a394b4e
 ## explicit
 github.com/divideandconquer/go-merge/merge
-# github.com/docker/cli v23.0.1+incompatible
+# github.com/docker/cli v23.0.3+incompatible
 ## explicit
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile


### PR DESCRIPTION
Manual attempt to bump version after dependabot issue.

**Also bump Go to 1.20** as Go 1.18 is now out of maintenance.