### PR TITLE
chore: fix also the linter warnings

### DIFF
--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pkg/mover"
 )
 
@@ -50,7 +51,7 @@ func init() {
 	rootCmd.AddCommand(chartCmd)
 }
 
-func validateChartArgs(cmd *cobra.Command, args []string) error {
+func validateChartArgs(_ *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("requires a chart argument")
 	} else if len(args) > 1 {

--- a/pkg/mover/chart.go
+++ b/pkg/mover/chart.go
@@ -73,9 +73,9 @@ func (l defaultLogger) Println(i ...interface{}) {
 
 type noLogger struct{}
 
-func (nl noLogger) Printf(format string, i ...interface{}) {}
+func (nl noLogger) Printf(_ string, _ ...interface{}) {}
 
-func (nl noLogger) Println(i ...interface{}) {}
+func (nl noLogger) Println(_ ...interface{}) {}
 
 // DefaultLogger to stdout
 var DefaultLogger Logger = defaultLogger{}
@@ -352,7 +352,7 @@ func (cm *ChartMover) loadImageHints(src *Source) error {
 
 // loadImageHintsFromBundle loads the image hints from the intermediate bundle
 func (cm *ChartMover) loadImageHintsFromBundle() error {
-	rawHints, err := cm.intermediateBundle.loadImageHints(cm.logger)
+	rawHints, err := cm.intermediateBundle.loadImageHints()
 	if err != nil {
 		return err
 	}
@@ -716,7 +716,7 @@ func saveChart(chart *chart.Chart, toChartFilename string) error {
 // load hints from either a given hints file or a chart-embedded hints file
 func loadImageHints(imageHintsFile string, chart *chart.Chart, log Logger) ([]byte, error) {
 	if imageHintsFile != "" {
-		rawHints, err := notNilData(loadImageHintsFromFile(imageHintsFile, log))
+		rawHints, err := notNilData(loadImageHintsFromFile(imageHintsFile))
 		if err != nil {
 			return nil, err
 		}
@@ -744,7 +744,7 @@ func loadImageHintsFromChart(chart *chart.Chart, log Logger) ([]byte, error) {
 }
 
 // loadImageHintsFromFile from a file
-func loadImageHintsFromFile(hintsFile string, log Logger) ([]byte, error) {
+func loadImageHintsFromFile(hintsFile string) ([]byte, error) {
 	contents, err := notNilData(os.ReadFile(hintsFile))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read the image patterns file: %w", err)

--- a/pkg/mover/intermediate.go
+++ b/pkg/mover/intermediate.go
@@ -14,8 +14,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal"
 	"helm.sh/helm/v3/pkg/chart"
+
+	"github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/internal"
 )
 
 var (
@@ -183,7 +184,7 @@ func (ib *intermediateBundle) extractChartTo(dir string) error {
 	return nil
 }
 
-func (ib *intermediateBundle) loadImageHints(log Logger) ([]byte, error) {
+func (ib *intermediateBundle) loadImageHints() ([]byte, error) {
 	r, err := openFromTar(ib.bundlePath, IntermediateBundleHintsFilename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract %s from bundle at %s: %w",

--- a/pkg/mover/tar.go
+++ b/pkg/mover/tar.go
@@ -132,9 +132,9 @@ func openFromTar(tarFile, filePath string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open tar file %s: %w", tarFile, err)
 	}
-	close := true
+	closeTar := true
 	defer func() {
-		if close {
+		if closeTar {
 			f.Close()
 		}
 	}()
@@ -153,7 +153,7 @@ func openFromTar(tarFile, filePath string) (io.ReadCloser, error) {
 				currentDir := filepath.Dir(filePath)
 				return openFromTar(tarFile, path.Join(currentDir, hdr.Linkname))
 			}
-			close = false
+			closeTar = false
 			return tarredFile{
 				Reader: tf,
 				Closer: f,


### PR DESCRIPTION
At https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/210 I fixed some errors returning by the linter action in the main branch. However, it seems for that action to pass, we should also fix the warnings.

```
  Warning: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
  Warning: redefines-builtin-id: redefinition of the built-in function close (revive)
  Warning: redefines-builtin-id: redefinition of the built-in function close (revive)
  Warning: unused-parameter: parameter 'format' seems to be unused, consider removing or renaming it as _ (revive)
  Warning: unused-parameter: parameter 'i' seems to be unused, consider removing or renaming it as _ (revive)
  Warning: unused-parameter: parameter 'log' seems to be unused, consider removing or renaming it as _ (revive)
  Warning: unused-parameter: parameter 'log' seems to be unused, consider removing or renaming it as _ (revive)
```