### PR TITLE
chore: update goreleaser.yml so it is compartible with latest version

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -30,6 +30,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,10 +19,18 @@ dockers:
     extra_files:
       - assets/docker-login.sh
 archives:
-  - replacements:
-      386: i386
-      amd64: x86_64
-    name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+  - format: tar.gz
+    name_template: >-
+      {{- .Binary }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
+    format_overrides:
+      - goos: windows
+        format: zip
     files:
       - README.md
 checksum:


### PR DESCRIPTION
Updates .goreleaser file format to work with the latest version:
* [The replacement section has been deprecated](https://goreleaser.com/deprecations/?h=replacements#archivesreplacements)
* The `--rm-dist` flag has been renamed to `--clean`